### PR TITLE
[Experimental] SIMD nonsense

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,17 @@ builder.LoadStrings("strings.txt")
 Both functions expects a text file with one pattern per line. `LoadPatterns` expects the pattern to
 be in hexadecimal form.
 
+## SIMD (experimental, Go 1.26)
+
+This library can use Go's experimental `simd/archsimd` package to accelerate
+root-state skipping when the pattern set has 16 or fewer distinct starting
+bytes. This is only available on amd64 with AVX and requires building with Go
+1.26 and `GOEXPERIMENT=simd` enabled.
+
+Example:
+
+    GOEXPERIMENT=simd gotip test ./...
+
 ## Storing
 
 Use `Encode` to store a `Trie` in gzip compressed binary format:

--- a/builder.go
+++ b/builder.go
@@ -206,6 +206,8 @@ func (tb *TrieBuilder) Build() *Trie {
 		}
 	}
 
+	trie.initPrefilter()
+
 	return trie
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/BobuSumisu/aho-corasick
 
-go 1.23.1
+go 1.26

--- a/prefilter.go
+++ b/prefilter.go
@@ -1,19 +1,22 @@
 package ahocorasick
 
+// rootPrefilter accelerates scanning at the root state by skipping bytes that
+// cannot start any pattern. It tracks up to 16 candidate bytes for SIMD use.
 type rootPrefilter struct {
-	bytes  [16]byte
-	blocks [16][16]byte
-	count  int
-	simd   bool
+	bytes  [16]byte     // Candidate bytes that transition away from root.
+	blocks [16][16]byte // SIMD broadcast blocks for each candidate byte.
+	count  int          // Number of candidates in bytes/blocks.
+	simd   bool         // Whether SIMD scanning is enabled for this trie.
 }
 
 func (p *rootPrefilter) init(rootTrans [256]uint32) {
 	p.count = 0
 	p.simd = false
 
-	for b := 0; b < 256; b++ {
+	for b := range 256 {
 		if rootTrans[b] != rootState {
 			if p.count == len(p.bytes) {
+				// Too many candidates for the SIMD prefilter; disable it.
 				p.count = 0
 				return
 			}
@@ -26,8 +29,9 @@ func (p *rootPrefilter) init(rootTrans [256]uint32) {
 		return
 	}
 
+	// Pre-broadcast each candidate byte for SIMD comparisons.
 	for i := 0; i < p.count; i++ {
-		for j := 0; j < 16; j++ {
+		for j := range 16 {
 			p.blocks[i][j] = p.bytes[i]
 		}
 	}

--- a/prefilter.go
+++ b/prefilter.go
@@ -1,0 +1,44 @@
+package ahocorasick
+
+type rootPrefilter struct {
+	bytes  [16]byte
+	blocks [16][16]byte
+	count  int
+	simd   bool
+}
+
+func (p *rootPrefilter) init(rootTrans [256]uint32) {
+	p.count = 0
+	p.simd = false
+
+	for b := 0; b < 256; b++ {
+		if rootTrans[b] != rootState {
+			if p.count == len(p.bytes) {
+				p.count = 0
+				return
+			}
+			p.bytes[p.count] = byte(b)
+			p.count++
+		}
+	}
+
+	if p.count == 0 {
+		return
+	}
+
+	for i := 0; i < p.count; i++ {
+		for j := 0; j < 16; j++ {
+			p.blocks[i][j] = p.bytes[i]
+		}
+	}
+
+	p.simd = p.enableSIMD()
+}
+
+func (tr *Trie) initPrefilter() {
+	if len(tr.failTrans) <= int(rootState) {
+		tr.prefilter = rootPrefilter{}
+		return
+	}
+	tr.prefilter.init(tr.failTrans[rootState])
+}

--- a/prefilter_nosimd.go
+++ b/prefilter_nosimd.go
@@ -1,0 +1,11 @@
+//go:build !goexperiment.simd || !amd64
+
+package ahocorasick
+
+func (p *rootPrefilter) enableSIMD() bool {
+	return false
+}
+
+func (p *rootPrefilter) nextCandidateSIMD(_ []byte, start int) int {
+	return start
+}

--- a/prefilter_simd_amd64.go
+++ b/prefilter_simd_amd64.go
@@ -1,0 +1,49 @@
+//go:build goexperiment.simd && amd64
+
+package ahocorasick
+
+import (
+	"math/bits"
+
+	"simd/archsimd"
+)
+
+func (p *rootPrefilter) enableSIMD() bool {
+	return p.count > 0 && archsimd.X86.AVX()
+}
+
+func (p *rootPrefilter) nextCandidateSIMD(input []byte, start int) int {
+	if p.count == 0 {
+		return len(input)
+	}
+
+	var needles [16]archsimd.Uint8x16
+	for i := 0; i < p.count; i++ {
+		needles[i] = archsimd.LoadUint8x16(&p.blocks[i])
+	}
+
+	i := start
+	n := len(input)
+	for i+16 <= n {
+		hay := archsimd.LoadUint8x16Slice(input[i : i+16])
+		var mask uint16
+		for j := 0; j < p.count; j++ {
+			mask |= hay.Equal(needles[j]).ToBits()
+		}
+		if mask != 0 {
+			return i + bits.TrailingZeros16(mask)
+		}
+		i += 16
+	}
+
+	for ; i < n; i++ {
+		b := input[i]
+		for j := 0; j < p.count; j++ {
+			if b == p.bytes[j] {
+				return i
+			}
+		}
+	}
+
+	return n
+}

--- a/prefilter_simd_amd64.go
+++ b/prefilter_simd_amd64.go
@@ -12,11 +12,14 @@ func (p *rootPrefilter) enableSIMD() bool {
 	return p.count > 0 && archsimd.X86.AVX()
 }
 
+// nextCandidateSIMD returns the next position at or after start that could
+// transition from the root state, or len(input) if none are found.
 func (p *rootPrefilter) nextCandidateSIMD(input []byte, start int) int {
 	if p.count == 0 {
 		return len(input)
 	}
 
+	// Load the broadcasted candidates once per call.
 	var needles [16]archsimd.Uint8x16
 	for i := 0; i < p.count; i++ {
 		needles[i] = archsimd.LoadUint8x16(&p.blocks[i])
@@ -31,11 +34,13 @@ func (p *rootPrefilter) nextCandidateSIMD(input []byte, start int) int {
 			mask |= hay.Equal(needles[j]).ToBits()
 		}
 		if mask != 0 {
+			// First set bit is the earliest candidate in this block.
 			return i + bits.TrailingZeros16(mask)
 		}
 		i += 16
 	}
 
+	// Scalar tail for any remaining bytes.
 	for ; i < n; i++ {
 		b := input[i]
 		for j := 0; j < p.count; j++ {

--- a/stream.go
+++ b/stream.go
@@ -128,7 +128,7 @@ func (dec *decoder) decode() (*Trie, error) {
 		return nil, err
 	}
 
-	return &Trie{
+	trie := &Trie{
 		failTrans: failTrans,
 		dictLink:  dictLink,
 		dict:      dict,
@@ -139,5 +139,8 @@ func (dec *decoder) decode() (*Trie, error) {
 		matchStructPool: sync.Pool{
 			New: func() any { return new(Match) },
 		},
-	}, nil
+	}
+	trie.initPrefilter()
+
+	return trie, nil
 }

--- a/trie.go
+++ b/trie.go
@@ -19,6 +19,7 @@ type Trie struct {
 
 	matchPool       sync.Pool // Pool for match slice pointers
 	matchStructPool sync.Pool // Pool for Match structs
+	prefilter       rootPrefilter
 }
 
 // Walk calls this function on any match, giving the end position, length of the matched bytes,
@@ -33,11 +34,20 @@ func (tr *Trie) Walk(input []byte, fn WalkFn) {
 	dict := tr.dict
 	pattern := tr.pattern
 	dictLink := tr.dictLink
+	prefilter := &tr.prefilter
 
 	s := rootState
 
 	inputLen := len(input)
-	for i := range inputLen {
+	for i := 0; i < inputLen; {
+		if s == rootState && prefilter.simd {
+			next := prefilter.nextCandidateSIMD(input, i)
+			if next >= inputLen {
+				return
+			}
+			i = next
+		}
+
 		s = failTrans[s][input[i]]
 
 		ds := dict[s]
@@ -52,6 +62,8 @@ func (tr *Trie) Walk(input []byte, fn WalkFn) {
 				}
 			}
 		}
+
+		i++
 	}
 }
 


### PR DESCRIPTION
## Summary
  - Add SIMD root-state prefilter (GOEXPERIMENT=simd + AVX) to skip non-candidate bytes. Kinda a bummer this only works on AMD :(
  - Non-SIMD builds unchanged.

  ## Benchmarks
  linux/amd64, go1.26rc2, AMD Ryzen 9 9950X

  Commands:

  go test -bench=BenchmarkMatchIbsen -benchmem -run=^$ -count=6 ./...
  GOEXPERIMENT=simd go test -bench=BenchmarkMatchIbsen -benchmem -run=^$ -count=6 ./...


  ### Time (sec/op)
  | Benchmark | nosimd | simd | delta |
  | --- | --- | --- | --- |
  | MatchIbsen/100-32 | 197.15n ± 1% | 99.34n ± 7% | -49.61% (p=0.002 n=6) |
  | MatchIbsen/1000-32 | 1825.5n ± 1% | 703.7n ± 4% | -61.45% (p=0.002 n=6) |
  | MatchIbsen/10000-32 | 19.174us ± 0% | 7.938us ± 0% | -58.60% (p=0.002 n=6) |
  | MatchIbsen/100000-32 | 199.97us ± 0% | 95.25us ± 1% | -52.37% (p=0.002 n=6) |
  | geomean | 6.095us | 2.696us | -55.76% |

  ### Memory
  B/op and allocs/op unchanged for 100, 1000, 10000; 100000 B/op improves -34.59% (p=0.002 n=6).