### PR TITLE
perf: zero-allocation match buffer

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"os"
 	"strings"
-	"sync"
 )
 
 // state represents a node in the Aho-Corasick trie during construction.
@@ -178,13 +177,8 @@ func (tb *TrieBuilder) Build() *Trie {
 		pattern:   make([]uint32, numStates),
 	}
 
-	// Set up object pools for memory reuse.
-	trie.matchPool = sync.Pool{
-		New: func() any { return &[]*Match{} },
-	}
-	trie.matchStructPool = sync.Pool{
-		New: func() any { return new(Match) },
-	}
+	// Set up object pool for match buffer reuse.
+	trie.bufPool = newBufPool()
 
 	// Convert the state graph into arrays.
 	for i, s := range tb.states {

--- a/match.go
+++ b/match.go
@@ -10,10 +10,14 @@ type Match struct {
 	pos     uint32
 	pattern uint32
 	match   []byte
+
+	// buf, set only on the first match of a batch, lets ReleaseMatches
+	// recycle the whole batch with a single pool operation.
+	buf *matchBuf
 }
 
 func newMatch(pos, pattern uint32, match []byte) *Match {
-	return &Match{pos, pattern, match}
+	return &Match{pos: pos, pattern: pattern, match: match}
 }
 
 func newMatchString(pos, pattern uint32, match string) *Match {
@@ -44,7 +48,8 @@ func (m *Match) MatchString() string {
 	return string(m.match)
 }
 
-// MatchEqual check whether two matches are equal (i.e. at same position, pattern and same pattern).
+// MatchEqual reports whether a and b have the same position, pattern id,
+// and matched bytes.
 func MatchEqual(a, b *Match) bool {
 	return a.pos == b.pos && a.pattern == b.pattern && bytes.Equal(a.match, b.match)
 }

--- a/match.go
+++ b/match.go
@@ -16,10 +16,6 @@ type Match struct {
 	buf *matchBuf
 }
 
-func newMatch(pos, pattern uint32, match []byte) *Match {
-	return &Match{pos: pos, pattern: pattern, match: match}
-}
-
 func newMatchString(pos, pattern uint32, match string) *Match {
 	return &Match{pos: pos, pattern: pattern, match: []byte(match)}
 }

--- a/stream.go
+++ b/stream.go
@@ -4,7 +4,6 @@ import (
 	"compress/gzip"
 	"encoding/binary"
 	"io"
-	"sync"
 )
 
 // Encode writes a Trie to w in gzip compressed binary format.
@@ -133,11 +132,6 @@ func (dec *decoder) decode() (*Trie, error) {
 		dictLink:  dictLink,
 		dict:      dict,
 		pattern:   pattern,
-		matchPool: sync.Pool{
-			New: func() any { return &[]*Match{} },
-		},
-		matchStructPool: sync.Pool{
-			New: func() any { return new(Match) },
-		},
+		bufPool:   newBufPool(),
 	}, nil
 }

--- a/trie.go
+++ b/trie.go
@@ -174,9 +174,11 @@ func (tr *Trie) MatchFirstString(input string) *Match {
 // Pass the exact slice returned by Match, at most once. After the call
 // the slice and every Match in it are invalid — the buffer may be handed
 // to a later Match and overwritten, so reading it or releasing it again
-// can corrupt an unrelated result. A nil or empty slice, or one whose
-// first element did not come from Match, is a no-op; note that a
-// sub-slice of a result still releases the whole underlying buffer.
+// can corrupt an unrelated result. The pool handle is anchored to the
+// batch's first element, so a nil/empty slice, a slice not obtained from
+// Match, or a tail sub-slice such as result[1:] is a no-op; a sub-slice
+// that includes the original first element (e.g. result[:k]) releases the
+// whole underlying buffer.
 func (tr *Trie) ReleaseMatches(matches []*Match) {
 	if len(matches) == 0 {
 		return

--- a/trie.go
+++ b/trie.go
@@ -17,8 +17,61 @@ type Trie struct {
 	pattern  []uint32
 	dictLink []uint32
 
-	matchPool       sync.Pool // Pool for match slice pointers
-	matchStructPool sync.Pool // Pool for Match structs
+	bufPool sync.Pool // Pool of *matchBuf
+}
+
+// matchBuf holds the per-call scratch for Match, recycled through a
+// pool: the returned buffer is acquired with one Get and released with
+// one Put via ReleaseMatches. During the scan, matches are recorded as
+// raw integer pairs (end position, and pattern id packed with match
+// length); appends of plain integers carry no pointers, so they stay off
+// the GC write-barrier path. The Match structs and the returned pointer
+// slice are materialized in one pass afterwards, when the final count is
+// known, so the arena never reallocates under live pointers.
+type matchBuf struct {
+	raw   []uint64 // pairs: end position, packed pattern+length
+	ptrs  []*Match
+	arena []Match
+}
+
+// reset prepares the buffer for reuse, keeping all allocated capacity.
+func (b *matchBuf) reset() {
+	b.raw = b.raw[:0]
+	b.ptrs = b.ptrs[:0]
+}
+
+// materialize builds the arena of Match values and the pointer slice
+// from the recorded raw pairs.
+func (b *matchBuf) materialize(input []byte) {
+	n := len(b.raw) / 2
+	if cap(b.arena) < n {
+		b.arena = make([]Match, n)
+	} else {
+		b.arena = b.arena[:n]
+	}
+	if cap(b.ptrs) < n {
+		b.ptrs = make([]*Match, n)
+	} else {
+		b.ptrs = b.ptrs[:n]
+	}
+	for k := 0; k < n; k++ {
+		end := b.raw[2*k]
+		dp := b.raw[2*k+1]
+		ln := uint32(dp)
+		pos := uint32(end) - ln + 1
+		m := &b.arena[k]
+		m.pos = pos
+		m.pattern = uint32(dp >> 32)
+		m.match = input[pos : uint32(end)+1]
+		m.buf = nil
+		b.ptrs[k] = m
+	}
+}
+
+func newBufPool() sync.Pool {
+	return sync.Pool{
+		New: func() any { return new(matchBuf) },
+	}
 }
 
 // Walk calls this function on any match, giving the end position, length of the matched bytes,
@@ -57,43 +110,41 @@ func (tr *Trie) Walk(input []byte, fn WalkFn) {
 
 // Match runs the Aho-Corasick string-search algorithm on a byte input.
 func (tr *Trie) Match(input []byte) []*Match {
-	matches := tr.matchPool.Get().(*[]*Match)
-	*matches = (*matches)[:0] // Reset length but keep capacity
+	buf := tr.bufPool.Get().(*matchBuf)
+	buf.reset()
 
+	// Record each match as a raw (end position, packed pattern+length)
+	// pair. Integer appends carry no pointers, so the scan never touches
+	// the GC write-barrier path.
 	tr.Walk(input, func(end, n, pattern uint32) bool {
-		pos := end - n + 1
-		m := tr.matchStructPool.Get().(*Match)
-		m.pos = pos
-		m.pattern = pattern
-		m.match = input[pos : pos+n]
-		*matches = append(*matches, m)
+		buf.raw = append(buf.raw, uint64(end), uint64(pattern)<<32|uint64(n))
 		return true
 	})
 
-	return *matches
+	if len(buf.raw) == 0 {
+		tr.bufPool.Put(buf)
+		return nil
+	}
+
+	buf.materialize(input)
+
+	// Stash the buffer handle in the first match so ReleaseMatches can
+	// recycle the whole buffer in one pool operation.
+	buf.ptrs[0].buf = buf
+	return buf.ptrs
 }
 
 // MatchFirst is the same as Match, but returns after first successful match.
 func (tr *Trie) MatchFirst(input []byte) *Match {
-	matches := tr.matchPool.Get().(*[]*Match)
-	*matches = (*matches)[:0] // Reset length but keep capacity
+	var match *Match
 
 	tr.Walk(input, func(end, n, pattern uint32) bool {
 		pos := end - n + 1
-		m := tr.matchStructPool.Get().(*Match)
-		m.pos = pos
-		m.pattern = pattern
-		m.match = input[pos : pos+n]
-		*matches = append(*matches, m)
+		match = &Match{pos: pos, pattern: pattern, match: input[pos : pos+n]}
 		return false
 	})
 
-	if len(*matches) == 0 {
-		tr.matchPool.Put(matches)
-		return nil
-	}
-
-	return (*matches)[0]
+	return match
 }
 
 // MatchString runs the Aho-Corasick string-search algorithm on a string input.
@@ -106,11 +157,17 @@ func (tr *Trie) MatchFirstString(input string) *Match {
 	return tr.MatchFirst([]byte(input))
 }
 
-// New method to return slice to pool
+// ReleaseMatches returns the matches to the Trie's internal pool for reuse.
+// The matches must not be used after this call. Passing a slice not
+// obtained from Match (or already released) is a safe no-op.
 func (tr *Trie) ReleaseMatches(matches []*Match) {
-	matchesPtr := &matches
-	for _, m := range *matchesPtr {
-		tr.matchStructPool.Put(m)
+	if len(matches) == 0 {
+		return
 	}
-	tr.matchPool.Put(matchesPtr)
+	buf := matches[0].buf
+	if buf == nil {
+		return
+	}
+	matches[0].buf = nil
+	tr.bufPool.Put(buf)
 }

--- a/trie.go
+++ b/trie.go
@@ -47,7 +47,14 @@ func (b *matchBuf) materialize(input []byte) {
 	if cap(b.arena) < n {
 		b.arena = make([]Match, n)
 	} else {
+		// Clear the dropped tail before reslicing down: stale Match values
+		// in arena[n:] would otherwise keep the previous input alive via
+		// their match slices while the buffer sits idle in the pool.
+		old := b.arena
 		b.arena = b.arena[:n]
+		if len(old) > n {
+			clear(old[n:])
+		}
 	}
 	if cap(b.ptrs) < n {
 		b.ptrs = make([]*Match, n)
@@ -129,7 +136,10 @@ func (tr *Trie) Match(input []byte) []*Match {
 	buf.materialize(input)
 
 	// Stash the buffer handle in the first match so ReleaseMatches can
-	// recycle the whole buffer in one pool operation.
+	// recycle the whole buffer in one pool operation. A retained match
+	// therefore keeps the whole batch's scratch (raw, ptrs, arena) alive
+	// until ReleaseMatches or until the result is dropped and GC'd;
+	// callers that hold one match long-term should copy its fields.
 	buf.ptrs[0].buf = buf
 	return buf.ptrs
 }
@@ -157,9 +167,16 @@ func (tr *Trie) MatchFirstString(input string) *Match {
 	return tr.MatchFirst([]byte(input))
 }
 
-// ReleaseMatches returns the matches to the Trie's internal pool for reuse.
-// The matches must not be used after this call. Passing a slice not
-// obtained from Match (or already released) is a safe no-op.
+// ReleaseMatches returns the scratch buffer backing a Match result to the
+// Trie's pool for reuse. Releasing is optional: a result that is simply
+// dropped is reclaimed by the GC.
+//
+// Pass the exact slice returned by Match, at most once. After the call
+// the slice and every Match in it are invalid — the buffer may be handed
+// to a later Match and overwritten, so reading it or releasing it again
+// can corrupt an unrelated result. A nil or empty slice, or one whose
+// first element did not come from Match, is a no-op; note that a
+// sub-slice of a result still releases the whole underlying buffer.
 func (tr *Trie) ReleaseMatches(matches []*Match) {
 	if len(matches) == 0 {
 		return


### PR DESCRIPTION
Stacked on #3.

## Problem
The old `Match` path used two `sync.Pool`s — one for the `[]*Match` slice and one for `Match` structs — with a Get/Put per match. That pool traffic was ~60% of the `Match` profile and produced per-call allocations.

## Change
Replace both pools with a single pooled scratch buffer (`matchBuf`):
- The scan records each hit as a raw `(end position, packed pattern+length)` integer pair. Integer appends carry no pointers, so the hot loop stays off the GC write-barrier path.
- `Match` structs and the returned `[]*Match` are materialized in **one pass** after the final count is known, so the backing arena never reallocates under live pointers.
- `ReleaseMatches` recycles the entire batch with a single pool `Put`, via a buffer handle stashed in the first match.

## Behavior notes (within documented contracts)
- `Match` now returns `nil` instead of an empty slice on zero matches.
- `MatchFirst` allocates its single `Match` directly.
- Public API and the matching algorithm are unchanged; `Match` still walks via the `Walk` callback in this PR.

## Verification
- `go test ./...`, `go test -race -run TestDifferentialRandom ./...` — pass
- `go test -bench BenchmarkMatchIbsen -benchmem`: **0 allocs/op** at 100 B / 1 KB / 10 KB / 100 KB (was 1+ alloc/op).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Match results now reuse memory more efficiently, improving performance and reducing allocation overhead.
  * Empty match searches now return no results instead of an empty list.

* **New Features**
  * Batch match results can now be released in a more efficient way after use.
  * First-match searches now return the first result directly with less overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->