### PR TITLE
perf: root self-loop skip fast path

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -200,6 +200,8 @@ func (tb *TrieBuilder) Build() *Trie {
 		}
 	}
 
+	trie.buildRootSkip()
+
 	return trie
 }
 

--- a/rootskip_bench_test.go
+++ b/rootskip_bench_test.go
@@ -1,0 +1,252 @@
+package ahocorasick
+
+// Benchmarks for the root self-loop skip, varying the two corpus properties
+// that determine its effect on match throughput.
+//
+// BenchmarkMatchIbsen measures one operating point: patterns[:10000] of an
+// alphabetically sorted word list all begin with 'a', so the root has one
+// stop byte (Walk dispatches to walkStopByte) and Ibsen has 3.8% stop-byte
+// density. It does not vary density and never reaches walkTable.
+//
+// The skip's effect depends on two properties, both swept here:
+//
+//   1. stop-byte density = fraction of haystack bytes that leave the root.
+//      Low density leaves long self-loop runs the skip jumps over; at high
+//      density the skip runs on nearly every byte and adds cost.
+//   2. number of distinct pattern first bytes. One selects the walkStopByte
+//      SWAR/IndexByte path; two or more select the walkTable OR-table path.
+//
+// The benchmarks use only the public API (NewTrieBuilder/AddStrings/Build/
+// Match/ReleaseMatches), which is stable across the perf branch stack, so
+// this file can be dropped onto any of those branches to compare them.
+
+import (
+	"bufio"
+	"math/rand"
+	"os"
+	"strings"
+	"testing"
+)
+
+// benchReadLines loads up to n non-empty trimmed lines (n<=0 => all).
+func benchReadLines(tb testing.TB, path string, n int) []string {
+	tb.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer f.Close()
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 0, 1<<20), 1<<20)
+	out := make([]string, 0, 1024)
+	for s.Scan() && (n <= 0 || len(out) < n) {
+		if t := strings.TrimSpace(s.Text()); t != "" {
+			out = append(out, t)
+		}
+	}
+	if err := s.Err(); err != nil {
+		tb.Fatal(err)
+	}
+	return out
+}
+
+// benchReadFile reads a whole file as bytes.
+func benchReadFile(tb testing.TB, path string) []byte {
+	tb.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return b
+}
+
+// spreadDict returns n patterns evenly sampled across the full word list.
+// The samples span the alphabet, so the trie has many root stop bytes and
+// Match takes walkTable. The sorted prefix all[:n] instead shares one first
+// letter and takes walkStopByte.
+func spreadDict(all []string, n int) []string {
+	if n >= len(all) {
+		return all
+	}
+	step := len(all) / n
+	if step < 1 {
+		step = 1
+	}
+	out := make([]string, 0, n)
+	for i := 0; i < len(all) && len(out) < n; i += step {
+		out = append(out, all[i])
+	}
+	return out
+}
+
+// synthHaystack builds a length-n haystack with stop-byte density near
+// `density`: each byte is a random stop byte with probability `density`,
+// otherwise a space (spaces self-loop at the root for every pattern set here).
+// The same `seed` produces the same haystack. Isolated stop bytes rarely form
+// full matches, so the dict/dictLink work after leaving the root stays small
+// and the measured difference between skip on and off is the skip itself.
+func synthHaystack(n int, stopBytes []byte, density float64, seed int64) []byte {
+	rng := rand.New(rand.NewSource(seed))
+	buf := make([]byte, n)
+	for i := range buf {
+		if rng.Float64() < density {
+			buf[i] = stopBytes[rng.Intn(len(stopBytes))]
+		} else {
+			buf[i] = ' '
+		}
+	}
+	return buf
+}
+
+func benchMatchOver(b *testing.B, trie *Trie, hay []byte) {
+	b.SetBytes(int64(len(hay)))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		m := trie.Match(hay)
+		trie.ReleaseMatches(m)
+	}
+}
+
+// BenchmarkRootSkip_RealCorpora matches a 10k-pattern trie over each real
+// haystack twice: once with the sorted all-'a' slice (one stop byte,
+// walkStopByte) and once with an evenly-spread dictionary (many stop bytes,
+// walkTable). Same pattern count as BenchmarkMatchIbsen; both paths measured.
+func BenchmarkRootSkip_RealCorpora(b *testing.B) {
+	all := benchReadLines(b, "./test_data/NSF-ordlisten.cleaned.txt", 0)
+	sortedDict := all[:10000]        // all begin with 'a' => walkStopByte
+	spread := spreadDict(all, 10000) // spans the alphabet => walkTable
+
+	haystacks := []struct{ name, path string }{
+		{"Ibsen_no", "./test_data/Ibsen.txt"},
+		{"GPL_en", "./test_data/gpl.txt"},
+		{"opphavsrett_no", "./test_data/opphavsrett.txt"},
+	}
+	dicts := []struct {
+		name string
+		pats []string
+	}{
+		{"sorted10k_1stopbyte", sortedDict},
+		{"spread10k_multistop", spread},
+	}
+	for _, d := range dicts {
+		trie := NewTrieBuilder().AddStrings(d.pats).Build()
+		for _, h := range haystacks {
+			hay := benchReadFile(b, h.path)
+			b.Run(d.name+"/"+h.name, func(b *testing.B) { benchMatchOver(b, trie, hay) })
+		}
+	}
+}
+
+// BenchmarkRootSkip_DensitySweep_SingleByte sweeps haystack stop-byte density
+// from 1% to 100% with a walkStopByte trie (patterns all begin with 'a', one
+// stop byte), locating the density at which the skip stops paying off.
+func BenchmarkRootSkip_DensitySweep_SingleByte(b *testing.B) {
+	all := benchReadLines(b, "./test_data/NSF-ordlisten.cleaned.txt", 0)
+	// Words starting with 'a': one stop byte, guaranteed walkStopByte.
+	var aWords []string
+	for _, w := range all {
+		if w[0] == 'a' {
+			aWords = append(aWords, w)
+			if len(aWords) == 10000 {
+				break
+			}
+		}
+	}
+	trie := NewTrieBuilder().AddStrings(aWords).Build()
+	const n = 262144
+	for _, pct := range []int{1, 2, 4, 8, 16, 32, 64, 100} {
+		hay := synthHaystack(n, []byte{'a'}, float64(pct)/100, 1)
+		b.Run(itoaPct(pct), func(b *testing.B) { benchMatchOver(b, trie, hay) })
+	}
+}
+
+// BenchmarkRootSkip_DensitySweep_MultiByte runs the same density sweep with a
+// walkTable trie (patterns begin with a..e, five stop bytes), exercising the
+// OR-table skip that BenchmarkMatchIbsen does not reach.
+func BenchmarkRootSkip_DensitySweep_MultiByte(b *testing.B) {
+	all := benchReadLines(b, "./test_data/NSF-ordlisten.cleaned.txt", 0)
+	stop := []byte{'a', 'b', 'c', 'd', 'e'}
+	// The word list is sorted, so take an equal share of words from each of
+	// the five first letters. Collecting the first 10000 words that start
+	// with any of a..e would take only 'a' words (there are far more than
+	// 10000) and yield one stop byte, not five.
+	byFirst := map[byte][]string{}
+	for _, w := range all {
+		if c := w[0]; c >= 'a' && c <= 'e' {
+			byFirst[c] = append(byFirst[c], w)
+		}
+	}
+	var pats []string
+	per := 10000 / len(stop)
+	for _, c := range stop {
+		ws := byFirst[c]
+		if len(ws) > per {
+			ws = ws[:per]
+		}
+		pats = append(pats, ws...)
+	}
+	trie := NewTrieBuilder().AddStrings(pats).Build()
+	const n = 262144
+	for _, pct := range []int{1, 2, 4, 8, 16, 32, 64, 100} {
+		hay := synthHaystack(n, stop, float64(pct)/100, 2)
+		b.Run(itoaPct(pct), func(b *testing.B) { benchMatchOver(b, trie, hay) })
+	}
+}
+
+// BenchmarkRootSkip_CardinalitySweep holds the haystack fixed (Ibsen) and
+// grows the number of distinct pattern first bytes from 1 to 26, crossing the
+// walkStopByte (1) to walkTable (>1) boundary.
+func BenchmarkRootSkip_CardinalitySweep(b *testing.B) {
+	all := benchReadLines(b, "./test_data/NSF-ordlisten.cleaned.txt", 0)
+	hay := benchReadFile(b, "./test_data/Ibsen.txt")
+	// Bucket words by first byte so we can assemble sets with a chosen
+	// number of distinct first letters.
+	byFirst := map[byte][]string{}
+	for _, w := range all {
+		byFirst[w[0]] = append(byFirst[w[0]], w)
+	}
+	letters := []byte("abcdefghijklmnopqrstuvwxyz")
+	for _, card := range []int{1, 2, 5, 13, 26} {
+		var pats []string
+		per := 10000 / card
+		got := 0
+		for _, l := range letters {
+			if got == card {
+				break
+			}
+			ws := byFirst[l]
+			if len(ws) == 0 {
+				continue
+			}
+			if len(ws) > per {
+				ws = ws[:per]
+			}
+			pats = append(pats, ws...)
+			got++
+		}
+		if got < card {
+			continue // not enough distinct first letters available
+		}
+		trie := NewTrieBuilder().AddStrings(pats).Build()
+		b.Run(itoaCard(card), func(b *testing.B) { benchMatchOver(b, trie, hay) })
+	}
+}
+
+// itoaPct and itoaCard build subtest labels without importing fmt.
+func itoaPct(p int) string  { return "density_" + itoa(p) + "pct" }
+func itoaCard(c int) string { return "firstbytes_" + itoa(c) }
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [8]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/rootskip_bench_test.go
+++ b/rootskip_bench_test.go
@@ -196,7 +196,10 @@ func BenchmarkRootSkip_DensitySweep_MultiByte(b *testing.B) {
 
 // BenchmarkRootSkip_CardinalitySweep holds the haystack fixed (Ibsen) and
 // grows the number of distinct pattern first bytes from 1 to 26, crossing the
-// walkStopByte (1) to walkTable (>1) boundary.
+// walkStopByte (1) to walkTable (>1) boundary. Natural-letter frequencies are
+// skewed, so adding first bytes also raises the haystack's stop-byte density;
+// the sweep therefore reports the measured density in each subtest label so
+// the cardinality and density effects can be told apart when reading results.
 func BenchmarkRootSkip_CardinalitySweep(b *testing.B) {
 	all := benchReadLines(b, "./test_data/NSF-ordlisten.cleaned.txt", 0)
 	hay := benchReadFile(b, "./test_data/Ibsen.txt")
@@ -228,8 +231,21 @@ func BenchmarkRootSkip_CardinalitySweep(b *testing.B) {
 		if got < card {
 			continue // not enough distinct first letters available
 		}
+		// Measure the actual stop-byte density this pattern set induces on
+		// the fixed haystack, so the confound with cardinality is visible.
+		var stop [256]bool
+		for _, p := range pats {
+			stop[p[0]] = true
+		}
+		stopCount := 0
+		for _, c := range hay {
+			if stop[c] {
+				stopCount++
+			}
+		}
+		densityPct := stopCount * 100 / len(hay)
 		trie := NewTrieBuilder().AddStrings(pats).Build()
-		b.Run(itoaCard(card), func(b *testing.B) { benchMatchOver(b, trie, hay) })
+		b.Run(itoaCard(card)+"/"+itoaPct(densityPct), func(b *testing.B) { benchMatchOver(b, trie, hay) })
 	}
 }
 

--- a/rootskip_test.go
+++ b/rootskip_test.go
@@ -196,26 +196,44 @@ func TestRootSkipSplitBoundaries(t *testing.T) {
 			maxLen = len(p)
 		}
 	}
-	for _, sz := range []int{1100, 2048, 20000, 50000, 131072} {
+	// planted returns a fresh sz-byte self-loop haystack with s copied in at
+	// pos, so each boundary case is validated in its own buffer and no plant
+	// overwrites another.
+	planted := func(sz, pos int, s string) []byte {
 		in := bytesFill(sz, ' ')
-		plant := func(pos int, s string) {
-			if pos >= 0 && pos+len(s) <= len(in) {
-				copy(in[pos:], s)
-			}
+		if pos >= 0 && pos+len(s) <= len(in) {
+			copy(in[pos:], s)
 		}
+		return in
+	}
+	for _, sz := range []int{1100, 2048, 20000, 50000, 131072} {
 		mid := sz / 2
 		for d := -maxLen; d <= maxLen; d++ {
-			plant(mid+d, "needle")
+			in := planted(sz, mid+d, "needle")
+			t.Run(fmt.Sprintf("sz=%d/mid%+d", sz, d), func(t *testing.T) {
+				checkAgainstNaive(t, patterns, in)
+			})
 		}
 		for w := 1; w <= 8; w++ {
 			cb := sz * w / 8
-			plant(cb-3, "abcdefghij")
-			plant(cb, "xyz")
+			for _, tc := range []struct {
+				pos int
+				s   string
+			}{
+				{cb - 3, "abcdefghij"},
+				{cb, "xyz"},
+			} {
+				in := planted(sz, tc.pos, tc.s)
+				t.Run(fmt.Sprintf("sz=%d/cb%d/%s", sz, w, tc.s), func(t *testing.T) {
+					checkAgainstNaive(t, patterns, in)
+				})
+			}
 		}
-		plant(sz-len("needle"), "needle") // ends exactly at input end
-		plant(0, "needle")                // starts at input start
-		t.Run(fmt.Sprintf("sz=%d", sz), func(t *testing.T) {
-			checkAgainstNaive(t, patterns, in)
+		t.Run(fmt.Sprintf("sz=%d/end", sz), func(t *testing.T) {
+			checkAgainstNaive(t, patterns, planted(sz, sz-len("needle"), "needle"))
+		})
+		t.Run(fmt.Sprintf("sz=%d/start", sz), func(t *testing.T) {
+			checkAgainstNaive(t, patterns, planted(sz, 0, "needle"))
 		})
 	}
 }

--- a/rootskip_test.go
+++ b/rootskip_test.go
@@ -310,4 +310,30 @@ func TestRootSkipSamplerDisableDecision(t *testing.T) {
 	if low.disabled {
 		t.Fatal("low density: gate should leave the skip enabled")
 	}
+
+	// Boundary: the decision flips at the exact 1/16 break-even. gap=15 gives
+	// density 1/16 (stopBytes*16 == rootBytes) and must disable; gap=16 gives
+	// 1/17, just below, and must stay enabled. These straddle the exact
+	// stopBytes*16 >= rootBytes threshold so a regression in that arithmetic is
+	// caught, unlike the extreme cases above.
+	atBreakeven := rootSkipSampler{budget: rootSkipSampleLen}
+	disabled = false
+	for i := 0; i < rootSkipSampleLen; i++ {
+		if atBreakeven.observe(15) {
+			disabled = true
+		}
+	}
+	if !disabled || !atBreakeven.disabled {
+		t.Fatalf("gap=15 (1/16 density): gate should disable the skip, got disabled=%v", atBreakeven.disabled)
+	}
+
+	belowBreakeven := rootSkipSampler{budget: rootSkipSampleLen}
+	for i := 0; i < rootSkipSampleLen; i++ {
+		if belowBreakeven.observe(16) {
+			t.Fatalf("gap=16 (below 1/16): gate disabled the skip after run %d", i)
+		}
+	}
+	if belowBreakeven.disabled {
+		t.Fatal("gap=16 (below 1/16): gate should leave the skip enabled")
+	}
 }

--- a/rootskip_test.go
+++ b/rootskip_test.go
@@ -239,11 +239,14 @@ func TestRootSkipSplitBoundaries(t *testing.T) {
 	}
 }
 
-// TestRootSkipDensityGate exercises both sides of walkTable's density gate:
-// a low-density input (sparse stop bytes, long self-loop runs) engages the
-// skip, and a high-density input (nearly every byte leaves the root)
-// disables it. The gate only toggles an optimization, so Match output must
-// equal the naive reference either way. Patterns start with several distinct
+// TestRootSkipDensityGate checks that walkTable's density gate — an
+// output-invisible optimization that only toggles whether root self-loops are
+// skipped — never changes Match output. It feeds a low-density input (sparse
+// stop bytes, long self-loop runs) and a high-density input (nearly every byte
+// leaves the root) and asserts both still equal the naive reference. The
+// gate's disable decision itself is not observable in Match output, so it is
+// asserted directly in TestRootSkipSamplerDisableDecision; this test only
+// guards correctness across densities. Patterns start with several distinct
 // bytes so the trie takes the multi-stop-byte walkTable path where the gate
 // lives.
 func TestRootSkipDensityGate(t *testing.T) {
@@ -257,7 +260,7 @@ func TestRootSkipDensityGate(t *testing.T) {
 	}
 
 	// High density: cycle through the stop-byte first letters so almost
-	// every byte leaves the root and the gate disables the skip.
+	// every byte leaves the root.
 	high := make([]byte, n)
 	firsts := []byte{'a', 'b', 'c', 'd', 'e'}
 	for i := range high {
@@ -268,10 +271,43 @@ func TestRootSkipDensityGate(t *testing.T) {
 		copy(high[pos:], "banana")
 	}
 
-	t.Run("low_density_skip_engaged", func(t *testing.T) {
+	t.Run("low_density", func(t *testing.T) {
 		checkAgainstNaive(t, patterns, low)
 	})
-	t.Run("high_density_skip_disabled", func(t *testing.T) {
+	t.Run("high_density", func(t *testing.T) {
 		checkAgainstNaive(t, patterns, high)
 	})
+}
+
+// TestRootSkipSamplerDisableDecision is a white-box check of walkTable's
+// density gate. The gate is invisible in Match output, so it cannot be
+// verified through checkAgainstNaive; instead this drives the exact sampler
+// walkTable uses and asserts the disable decision on both sides of the ~1/16
+// break-even.
+func TestRootSkipSamplerDisableDecision(t *testing.T) {
+	// High density: each run is one self-loop byte then a stop byte (gap=1 =>
+	// 2 bytes/run at 1/2 density, far above 1/16). Once the budget is spent,
+	// the skip must be disabled.
+	high := rootSkipSampler{budget: rootSkipSampleLen}
+	disabled := false
+	for i := 0; i < rootSkipSampleLen; i++ {
+		if high.observe(1) {
+			disabled = true
+		}
+	}
+	if !disabled || !high.disabled {
+		t.Fatalf("high density: gate should disable the skip, got disabled=%v", high.disabled)
+	}
+
+	// Low density: long self-loop runs between stop bytes (gap=1024 => ~1/1025
+	// density, far below 1/16). The skip must stay enabled.
+	low := rootSkipSampler{budget: rootSkipSampleLen}
+	for i := 0; i < 100; i++ {
+		if low.observe(1024) {
+			t.Fatalf("low density: gate disabled the skip after run %d", i)
+		}
+	}
+	if low.disabled {
+		t.Fatal("low density: gate should leave the skip enabled")
+	}
 }

--- a/rootskip_test.go
+++ b/rootskip_test.go
@@ -182,12 +182,13 @@ func TestRootSkipMatchAtExactEnd(t *testing.T) {
 }
 
 // TestRootSkipSplitBoundaries plants matches at and around the input midpoint
-// and every 1/8 chunk boundary, over inputs large enough to trigger the
-// dual-cursor scan (>1KB) and the parallel scan (>16KB). On this branch these
-// route through the sequential path; on the parallel and dual-cursor PRs the
-// split arithmetic decides which scan reports a match ending near a boundary,
-// and an off-by-one there drops or duplicates it. Matches sit at every offset
-// within maxLen of a boundary so a straddling match is exercised on both sides.
+// and every 1/8 chunk boundary, over inputs spanning the size thresholds at
+// which a chunked or parallel scan may partition the work (>1KB and >16KB). A
+// match that straddles a chunk boundary must be reported exactly once —
+// neither dropped nor duplicated — however the input is partitioned; an
+// off-by-one in the boundary ownership arithmetic breaks that. Matches sit at
+// every offset within maxLen of a boundary so a straddling match is exercised
+// on both sides.
 func TestRootSkipSplitBoundaries(t *testing.T) {
 	patterns := []string{"needle", "haystackNEEDLE", "abcdefghij", "xyz"}
 	maxLen := 0

--- a/rootskip_test.go
+++ b/rootskip_test.go
@@ -1,0 +1,258 @@
+package ahocorasick
+
+// Correctness tests for the root self-loop skip, checking Match against the
+// naive reference (naiveMatch, differential_test.go) at boundaries a random
+// fuzzer reaches only by chance:
+//
+//   - the SWAR word scan reads 8-byte words, so a stop byte's offset within a
+//     word (0..7) and gaps that cross word boundaries take different branches;
+//   - after k==3 (4 SWAR words, 32 skipped bytes) walkStopByte switches to
+//     bytes.IndexByte for the rest of the gap;
+//   - the sub-8-byte tail (i+8 > inputLen) uses a byte-at-a-time loop and the
+//     return-on-i==inputLen guard;
+//   - one stop byte selects walkStopByte, and any other count (zero, or two
+//     or more) selects walkTable;
+//   - matches whose end is the final input byte, right after a skip.
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// checkAgainstNaive builds a trie and asserts Match agrees with naiveMatch
+// exactly, comparing as sorted (pos, pattern, len) sets to avoid depending on
+// emission order.
+func checkAgainstNaive(t *testing.T, patterns []string, input []byte) {
+	t.Helper()
+	trie := NewTrieBuilder().AddStrings(patterns).Build()
+	got := trie.Match(input)
+	defer trie.ReleaseMatches(got)
+
+	gotTriples := make([][3]uint32, 0, len(got))
+	for _, m := range got {
+		gotTriples = append(gotTriples, [3]uint32{m.Pos(), m.Pattern(), uint32(len(m.Match()))})
+	}
+	want := naiveMatch(patterns, input)
+
+	norm := func(s [][3]uint32) [][3]uint32 {
+		c := make([][3]uint32, len(s))
+		copy(c, s)
+		sort.Slice(c, func(i, j int) bool {
+			if c[i][0] != c[j][0] {
+				return c[i][0] < c[j][0]
+			}
+			if c[i][2] != c[j][2] {
+				return c[i][2] < c[j][2]
+			}
+			return c[i][1] < c[j][1]
+		})
+		return c
+	}
+	g, w := norm(gotTriples), norm(want)
+	if len(g) != len(w) {
+		t.Fatalf("match count: got %d, want %d\n  got=%v\n want=%v", len(g), len(w), g, w)
+	}
+	for i := range g {
+		if g[i] != w[i] {
+			t.Fatalf("match %d: got %v, want %v\n  full got=%v\n full want=%v", i, g[i], w[i], g, w)
+		}
+	}
+}
+
+// bytesFill makes a slice of n copies of c.
+func bytesFill(n int, c byte) []byte {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = c
+	}
+	return b
+}
+
+// TestRootSkipSingleStopByteAlignments places the single stop byte 'a' at
+// every offset relative to the 8-byte SWAR word, with fillers 'x' that
+// self-loop at the root, so the SWAR scan, tail loop, and match-at-end paths
+// are all exercised.
+func TestRootSkipSingleStopByteAlignments(t *testing.T) {
+	patterns := []string{"ab", "a"}
+	// gaps chosen to land the stop byte before/at/after word boundaries and
+	// to trigger the IndexByte escalation (gaps >= 32).
+	for _, gap := range []int{0, 1, 7, 8, 9, 15, 16, 31, 32, 33, 40, 63, 64, 100} {
+		for _, trailer := range []string{"ab", "a", "xx", ""} {
+			input := append(bytesFill(gap, 'x'), []byte("ab")...)
+			input = append(input, []byte(trailer)...)
+			t.Run(fmt.Sprintf("gap=%d/trailer=%q", gap, trailer), func(t *testing.T) {
+				checkAgainstNaive(t, patterns, input)
+			})
+		}
+	}
+}
+
+// TestRootSkipLongGapIndexByte forces the bytes.IndexByte escalation: a run
+// of self-loop bytes far longer than 4 SWAR words (32 bytes) before the stop
+// byte, plus the no-more-stop-bytes case (skip to end).
+func TestRootSkipLongGapIndexByte(t *testing.T) {
+	patterns := []string{"needle", "n"}
+	for _, gap := range []int{33, 64, 65, 127, 128, 1000, 5000} {
+		input := append(bytesFill(gap, ' '), []byte("needle")...)
+		// Also a long trailing gap with no further stop byte.
+		input = append(input, bytesFill(gap, ' ')...)
+		t.Run(fmt.Sprintf("gap=%d", gap), func(t *testing.T) {
+			checkAgainstNaive(t, patterns, input)
+		})
+	}
+	// Pure self-loop input: never leaves root, must return no matches.
+	checkAgainstNaive(t, patterns, bytesFill(10000, ' '))
+}
+
+// TestRootSkipMultiStopByteTable exercises walkTable: two or more distinct
+// first bytes route through the rootStop OR-table skip instead of the SWAR
+// path. Sweeps density-like patterns and alignments.
+func TestRootSkipMultiStopByteTable(t *testing.T) {
+	patterns := []string{"apple", "banana", "cherry", "a", "b", "c"} // first bytes a,b,c => table
+	inputs := [][]byte{
+		[]byte("apple banana cherry"),
+		append(bytesFill(50, ' '), []byte("apple")...),
+		append(append(bytesFill(9, ' '), []byte("banana")...), bytesFill(40, ' ')...),
+		[]byte("aaaabbbbccccapplebananacherry"),
+		bytesFill(100, ' '), // never leaves root
+	}
+	for i, in := range inputs {
+		t.Run(fmt.Sprintf("input%d", i), func(t *testing.T) {
+			checkAgainstNaive(t, patterns, in)
+		})
+	}
+}
+
+// TestRootSkipEveryByteStops is the walkStopByte worst case: the haystack is
+// all stop bytes, so the skip never advances past the current position and
+// the automaton must still find every match.
+func TestRootSkipEveryByteStops(t *testing.T) {
+	patterns := []string{"aa", "a"}
+	for _, n := range []int{1, 7, 8, 9, 16, 33, 100} {
+		t.Run(fmt.Sprintf("n=%d", n), func(t *testing.T) {
+			checkAgainstNaive(t, patterns, bytesFill(n, 'a'))
+		})
+	}
+}
+
+// TestRootSkipReturnToRootMidInput checks skips that re-engage after the
+// automaton returns to the root partway through: a match, then a long gap,
+// then another match — the s==rootState re-entry into the skip must be
+// correct, including when the trailing match ends the input.
+func TestRootSkipReturnToRootMidInput(t *testing.T) {
+	patterns := []string{"cat", "dog"} // single first-byte? c and d => table path
+	for _, gap := range []int{5, 8, 33, 200} {
+		input := []byte("cat")
+		input = append(input, bytesFill(gap, ' ')...)
+		input = append(input, []byte("dog")...)
+		t.Run(fmt.Sprintf("gap=%d", gap), func(t *testing.T) {
+			checkAgainstNaive(t, patterns, input)
+		})
+	}
+	// Single stop byte variant (walkStopByte) with re-entry.
+	single := []string{"aXa", "a"} // first byte only 'a'
+	for _, gap := range []int{5, 8, 33, 200} {
+		input := []byte("aXa")
+		input = append(input, bytesFill(gap, ' ')...)
+		input = append(input, []byte("aXa")...)
+		t.Run(fmt.Sprintf("single/gap=%d", gap), func(t *testing.T) {
+			checkAgainstNaive(t, single, input)
+		})
+	}
+}
+
+// TestRootSkipMatchAtExactEnd matches ending at the final byte, right after a
+// skip of each boundary length, so the i==inputLen guard in each walk function
+// does not drop a final match. The single case uses patterns "ab" and "a"
+// (both start with 'a', one stop byte => walkStopByte); the multi case uses
+// "cd" and "ef" (two stop bytes => walkTable). Gap bytes ('x', ' ') are not a
+// first byte of either pattern set, so they self-loop and trigger the skip.
+func TestRootSkipMatchAtExactEnd(t *testing.T) {
+	for _, gap := range []int{0, 7, 8, 32, 33, 100} {
+		in1 := append(bytesFill(gap, 'x'), []byte("ab")...)
+		t.Run(fmt.Sprintf("single/gap=%d", gap), func(t *testing.T) {
+			checkAgainstNaive(t, []string{"ab", "a"}, in1) // one stop byte => walkStopByte
+		})
+		in2 := append(bytesFill(gap, ' '), []byte("cd")...)
+		t.Run(fmt.Sprintf("multi/gap=%d", gap), func(t *testing.T) {
+			checkAgainstNaive(t, []string{"cd", "ef"}, in2) // two stop bytes => walkTable
+		})
+	}
+}
+
+// TestRootSkipSplitBoundaries plants matches at and around the input midpoint
+// and every 1/8 chunk boundary, over inputs large enough to trigger the
+// dual-cursor scan (>1KB) and the parallel scan (>16KB). On this branch these
+// route through the sequential path; on the parallel and dual-cursor PRs the
+// split arithmetic decides which scan reports a match ending near a boundary,
+// and an off-by-one there drops or duplicates it. Matches sit at every offset
+// within maxLen of a boundary so a straddling match is exercised on both sides.
+func TestRootSkipSplitBoundaries(t *testing.T) {
+	patterns := []string{"needle", "haystackNEEDLE", "abcdefghij", "xyz"}
+	maxLen := 0
+	for _, p := range patterns {
+		if len(p) > maxLen {
+			maxLen = len(p)
+		}
+	}
+	for _, sz := range []int{1100, 2048, 20000, 50000, 131072} {
+		in := bytesFill(sz, ' ')
+		plant := func(pos int, s string) {
+			if pos >= 0 && pos+len(s) <= len(in) {
+				copy(in[pos:], s)
+			}
+		}
+		mid := sz / 2
+		for d := -maxLen; d <= maxLen; d++ {
+			plant(mid+d, "needle")
+		}
+		for w := 1; w <= 8; w++ {
+			cb := sz * w / 8
+			plant(cb-3, "abcdefghij")
+			plant(cb, "xyz")
+		}
+		plant(sz-len("needle"), "needle") // ends exactly at input end
+		plant(0, "needle")                // starts at input start
+		t.Run(fmt.Sprintf("sz=%d", sz), func(t *testing.T) {
+			checkAgainstNaive(t, patterns, in)
+		})
+	}
+}
+
+// TestRootSkipDensityGate exercises both sides of walkTable's density gate:
+// a low-density input (sparse stop bytes, long self-loop runs) engages the
+// skip, and a high-density input (nearly every byte leaves the root)
+// disables it. The gate only toggles an optimization, so Match output must
+// equal the naive reference either way. Patterns start with several distinct
+// bytes so the trie takes the multi-stop-byte walkTable path where the gate
+// lives.
+func TestRootSkipDensityGate(t *testing.T) {
+	patterns := []string{"apple", "banana", "cherry", "date", "elder", "a", "e"}
+	n := 20000
+
+	// Low density: mostly spaces (self-loop), rare planted matches.
+	low := bytesFill(n, ' ')
+	for pos := 0; pos+6 < n; pos += 500 {
+		copy(low[pos:], "cherry")
+	}
+
+	// High density: cycle through the stop-byte first letters so almost
+	// every byte leaves the root and the gate disables the skip.
+	high := make([]byte, n)
+	firsts := []byte{'a', 'b', 'c', 'd', 'e'}
+	for i := range high {
+		high[i] = firsts[i%len(firsts)]
+	}
+	// Sprinkle full patterns so there is real match work too.
+	for pos := 0; pos+6 < n; pos += 137 {
+		copy(high[pos:], "banana")
+	}
+
+	t.Run("low_density_skip_engaged", func(t *testing.T) {
+		checkAgainstNaive(t, patterns, low)
+	})
+	t.Run("high_density_skip_disabled", func(t *testing.T) {
+		checkAgainstNaive(t, patterns, high)
+	})
+}

--- a/stream.go
+++ b/stream.go
@@ -107,12 +107,19 @@ func (dec *decoder) decode() (*Trie, error) {
 	// root, so buildRootSkip can index failTrans[rootState]. Reject anything
 	// else with an error rather than panicking on a truncated or corrupt stream.
 	//
-	// maxDecodeStates also bounds the up-front allocation: failTrans costs 1KB
-	// per state, so an internally consistent but huge count would otherwise
-	// reach make(...) and panic on slice-allocation limits before any data is
-	// read. The bound is far above any realistic automaton (the full NSF word
-	// list in test_data is ~1.2M states), so it never rejects a real trie.
-	const maxDecodeStates = 1 << 24
+	// The dominant allocation is failTrans: one [256]uint32 row (1 KiB) per
+	// state, read straight into place below (no transient flat copy), so the
+	// state count is also the peak allocation. Bound it by an explicit byte
+	// budget so the guard matches the real allocation size and a
+	// corrupt-but-consistent length cannot OOM the process before any
+	// transition data is read. The budget is far above any realistic automaton
+	// (the full NSF word list in test_data is ~1.2M states ≈ 1.2 GiB of rows),
+	// so it never rejects a real trie.
+	const (
+		failTransRowBytes = 256 * 4 // one [256]uint32 transition row
+		maxDecodeBytes    = 4 << 30 // 4 GiB budget for failTrans rows
+		maxDecodeStates   = maxDecodeBytes / failTransRowBytes
+	)
 	if failTransLen < 2 || dictLen != failTransLen || dictLinkLen != failTransLen || patternLen != failTransLen {
 		return nil, fmt.Errorf("ahocorasick: corrupt trie: inconsistent table lengths (dict=%d failTrans=%d dictLink=%d pattern=%d)", dictLen, failTransLen, dictLinkLen, patternLen)
 	}
@@ -126,14 +133,14 @@ func (dec *decoder) decode() (*Trie, error) {
 		return nil, err
 	}
 
-	// Read and reshape failTrans
+	// Read failTrans one row at a time straight into place. Reading the whole
+	// table into a temporary flat slice first would double the peak allocation
+	// (another maxDecodeBytes), so decode row by row instead.
 	failTrans := make([][256]uint32, failTransLen)
-	flatFailTrans := make([]uint32, failTransLen*256)
-	if err := binary.Read(r, binary.LittleEndian, flatFailTrans); err != nil {
-		return nil, err
-	}
 	for i := range failTrans {
-		copy(failTrans[i][:], flatFailTrans[i*256:(i+1)*256])
+		if err := binary.Read(r, binary.LittleEndian, failTrans[i][:]); err != nil {
+			return nil, err
+		}
 	}
 
 	dictLink := make([]uint32, dictLinkLen)

--- a/stream.go
+++ b/stream.go
@@ -127,11 +127,13 @@ func (dec *decoder) decode() (*Trie, error) {
 		return nil, err
 	}
 
-	return &Trie{
+	trie := &Trie{
 		failTrans: failTrans,
 		dictLink:  dictLink,
 		dict:      dict,
 		pattern:   pattern,
 		bufPool:   newBufPool(),
-	}, nil
+	}
+	trie.buildRootSkip()
+	return trie, nil
 }

--- a/stream.go
+++ b/stream.go
@@ -13,10 +13,29 @@ func Encode(w io.Writer, trie *Trie) error {
 	return enc.encode(trie)
 }
 
-// Decode reads a Trie in gzip compressed binary format from r.
+// DecodeMaxStates is the default upper bound Decode places on the number of
+// automaton states it will accept from a stream. A decoded trie's memory is
+// dominated by failTrans at one [256]uint32 row (1 KiB) per state, so this is
+// effectively a ~4 GiB ceiling. It sits far above any realistic automaton (the
+// full NSF word list in test_data is ~1.2M states ≈ 1.2 GiB), so Decode never
+// rejects a real trie. Callers deserializing untrusted input on a
+// memory-constrained process should call DecodeWithMaxStates with a lower bound.
+const DecodeMaxStates = (4 << 30) / (256 * 4) // 4 GiB of failTrans rows
+
+// Decode reads a Trie in gzip compressed binary format from r, accepting up to
+// DecodeMaxStates states.
 func Decode(r io.Reader) (*Trie, error) {
+	return DecodeWithMaxStates(r, DecodeMaxStates)
+}
+
+// DecodeWithMaxStates is Decode with a caller-supplied ceiling on the number of
+// automaton states. The bound caps the memory a corrupt or hostile stream can
+// make Decode allocate — failTrans costs one [256]uint32 row (1 KiB) per state
+// — so choose a value the process can afford. A non-positive maxStates falls
+// back to DecodeMaxStates.
+func DecodeWithMaxStates(r io.Reader, maxStates int) (*Trie, error) {
 	dec := newDecoder(r)
-	return dec.decode()
+	return dec.decode(maxStates)
 }
 
 type encoder struct {
@@ -79,7 +98,11 @@ func newDecoder(r io.Reader) *decoder {
 	}
 }
 
-func (dec *decoder) decode() (*Trie, error) {
+func (dec *decoder) decode(maxStates int) (*Trie, error) {
+	if maxStates <= 0 {
+		maxStates = DecodeMaxStates
+	}
+
 	r, err := gzip.NewReader(dec.r)
 	if err != nil {
 		return nil, err
@@ -107,24 +130,17 @@ func (dec *decoder) decode() (*Trie, error) {
 	// root, so buildRootSkip can index failTrans[rootState]. Reject anything
 	// else with an error rather than panicking on a truncated or corrupt stream.
 	//
-	// The dominant allocation is failTrans: one [256]uint32 row (1 KiB) per
-	// state, read straight into place below (no transient flat copy), so the
-	// state count is also the peak allocation. Bound it by an explicit byte
-	// budget so the guard matches the real allocation size and a
-	// corrupt-but-consistent length cannot OOM the process before any
-	// transition data is read. The budget is far above any realistic automaton
-	// (the full NSF word list in test_data is ~1.2M states ≈ 1.2 GiB of rows),
-	// so it never rejects a real trie.
-	const (
-		failTransRowBytes = 256 * 4 // one [256]uint32 transition row
-		maxDecodeBytes    = 4 << 30 // 4 GiB budget for failTrans rows
-		maxDecodeStates   = maxDecodeBytes / failTransRowBytes
-	)
+	// maxStates caps the memory a corrupt or hostile stream can make Decode
+	// allocate: failTrans dominates at one [256]uint32 row (1 KiB) per state.
+	// failTrans is also grown incrementally as rows are read (below), so a
+	// stream that declares a huge count but carries little data cannot force a
+	// large up-front allocation — the reservation tracks the bytes actually
+	// delivered, bounded by maxStates.
 	if failTransLen < 2 || dictLen != failTransLen || dictLinkLen != failTransLen || patternLen != failTransLen {
 		return nil, fmt.Errorf("ahocorasick: corrupt trie: inconsistent table lengths (dict=%d failTrans=%d dictLink=%d pattern=%d)", dictLen, failTransLen, dictLinkLen, patternLen)
 	}
-	if failTransLen > maxDecodeStates {
-		return nil, fmt.Errorf("ahocorasick: corrupt trie: %d states exceeds decode limit %d", failTransLen, maxDecodeStates)
+	if failTransLen > uint64(maxStates) {
+		return nil, fmt.Errorf("ahocorasick: corrupt trie: %d states exceeds decode limit %d", failTransLen, maxStates)
 	}
 
 	// Allocate memory and read the actual data
@@ -133,11 +149,18 @@ func (dec *decoder) decode() (*Trie, error) {
 		return nil, err
 	}
 
-	// Read failTrans one row at a time straight into place. Reading the whole
-	// table into a temporary flat slice first would double the peak allocation
-	// (another maxDecodeBytes), so decode row by row instead.
-	failTrans := make([][256]uint32, failTransLen)
-	for i := range failTrans {
+	// Grow failTrans as rows are read rather than allocating the declared count
+	// up front, so a stream that declares many states but carries few rows only
+	// reserves memory proportional to the data actually delivered (it then hits
+	// EOF and errors) instead of forcing a full up-front allocation.
+	const initialFailTransCap = 1024 // ~1 MiB; append grows it as rows arrive
+	initCap := failTransLen
+	if initCap > initialFailTransCap {
+		initCap = initialFailTransCap
+	}
+	failTrans := make([][256]uint32, 0, initCap)
+	for i := uint64(0); i < failTransLen; i++ {
+		failTrans = append(failTrans, [256]uint32{})
 		if err := binary.Read(r, binary.LittleEndian, failTrans[i][:]); err != nil {
 			return nil, err
 		}

--- a/stream.go
+++ b/stream.go
@@ -106,8 +106,18 @@ func (dec *decoder) decode() (*Trie, error) {
 	// state across all four arrays and at least the unused state 0 plus the
 	// root, so buildRootSkip can index failTrans[rootState]. Reject anything
 	// else with an error rather than panicking on a truncated or corrupt stream.
+	//
+	// maxDecodeStates also bounds the up-front allocation: failTrans costs 1KB
+	// per state, so an internally consistent but huge count would otherwise
+	// reach make(...) and panic on slice-allocation limits before any data is
+	// read. The bound is far above any realistic automaton (the full NSF word
+	// list in test_data is ~1.2M states), so it never rejects a real trie.
+	const maxDecodeStates = 1 << 24
 	if failTransLen < 2 || dictLen != failTransLen || dictLinkLen != failTransLen || patternLen != failTransLen {
 		return nil, fmt.Errorf("ahocorasick: corrupt trie: inconsistent table lengths (dict=%d failTrans=%d dictLink=%d pattern=%d)", dictLen, failTransLen, dictLinkLen, patternLen)
+	}
+	if failTransLen > maxDecodeStates {
+		return nil, fmt.Errorf("ahocorasick: corrupt trie: %d states exceeds decode limit %d", failTransLen, maxDecodeStates)
 	}
 
 	// Allocate memory and read the actual data

--- a/stream.go
+++ b/stream.go
@@ -3,6 +3,7 @@ package ahocorasick
 import (
 	"compress/gzip"
 	"encoding/binary"
+	"fmt"
 	"io"
 )
 
@@ -99,6 +100,14 @@ func (dec *decoder) decode() (*Trie, error) {
 	}
 	if err := binary.Read(r, binary.LittleEndian, &patternLen); err != nil {
 		return nil, err
+	}
+
+	// Decode operates on untrusted input. A well-formed trie has one row per
+	// state across all four arrays and at least the unused state 0 plus the
+	// root, so buildRootSkip can index failTrans[rootState]. Reject anything
+	// else with an error rather than panicking on a truncated or corrupt stream.
+	if failTransLen < 2 || dictLen != failTransLen || dictLinkLen != failTransLen || patternLen != failTransLen {
+		return nil, fmt.Errorf("ahocorasick: corrupt trie: inconsistent table lengths (dict=%d failTrans=%d dictLink=%d pattern=%d)", dictLen, failTransLen, dictLinkLen, patternLen)
 	}
 
 	// Allocate memory and read the actual data

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,6 +2,8 @@ package ahocorasick
 
 import (
 	"bytes"
+	"compress/gzip"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"testing"
@@ -80,5 +82,73 @@ func TestReadAndWriteTrie(t *testing.T) {
 
 	if len(matches) != 3 {
 		t.Errorf("expected 3 matches, got %d", len(matches))
+	}
+}
+
+// gzipTrieHeader builds a gzip stream with the four length prefixes Decode
+// reads first, optionally followed by raw payload, for exercising Decode's
+// untrusted-input guards without a full valid trie.
+func gzipTrieHeader(t *testing.T, dictLen, failTransLen, dictLinkLen, patternLen uint64, payload []byte) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	for _, n := range []uint64{dictLen, failTransLen, dictLinkLen, patternLen} {
+		if err := binary.Write(w, binary.LittleEndian, n); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(payload) > 0 {
+		if _, err := w.Write(payload); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return &buf
+}
+
+// TestDecodeRejectsOversizedStateCount checks that a stream declaring more
+// states than the limit is rejected up front, before any table allocation.
+func TestDecodeRejectsOversizedStateCount(t *testing.T) {
+	huge := uint64(DecodeMaxStates) + 1
+	buf := gzipTrieHeader(t, huge, huge, huge, huge, nil)
+	if _, err := Decode(buf); err == nil {
+		t.Fatal("expected error for state count above DecodeMaxStates, got nil")
+	}
+}
+
+// TestDecodeWithMaxStatesEnforcesCallerLimit checks the caller-supplied bound:
+// a real trie is rejected under a tight limit but decodes under the default.
+func TestDecodeWithMaxStatesEnforcesCallerLimit(t *testing.T) {
+	trie := NewTrieBuilder().AddStrings([]string{"or", "amet"}).Build()
+
+	var tight bytes.Buffer
+	if err := Encode(&tight, trie); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeWithMaxStates(&tight, 1); err == nil {
+		t.Fatal("expected error when trie exceeds caller maxStates=1, got nil")
+	}
+
+	var ok bytes.Buffer
+	if err := Encode(&ok, trie); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := DecodeWithMaxStates(&ok, DecodeMaxStates); err != nil {
+		t.Fatalf("expected default-limit decode to succeed, got %v", err)
+	}
+}
+
+// TestDecodeTruncatedBeforeFailTrans exercises the incremental failTrans path:
+// a stream that declares many states (within the limit) but is truncated after
+// the dict rows must return an error, never panic, without reserving the full
+// declared failTrans up front.
+func TestDecodeTruncatedBeforeFailTrans(t *testing.T) {
+	const n = 100000                 // within DecodeMaxStates
+	dictPayload := make([]byte, n*4) // n zero uint32s for dict; failTrans absent
+	buf := gzipTrieHeader(t, n, n, n, n, dictPayload)
+	if _, err := Decode(buf); err == nil {
+		t.Fatal("expected error for stream truncated before failTrans, got nil")
 	}
 }

--- a/trie.go
+++ b/trie.go
@@ -1,6 +1,9 @@
 package ahocorasick
 
 import (
+	"bytes"
+	"encoding/binary"
+	"math/bits"
 	"sync"
 )
 
@@ -16,6 +19,18 @@ type Trie struct {
 	dict     []uint32
 	pattern  []uint32
 	dictLink []uint32
+
+	// rootStop[b] is 1 if byte b moves the automaton out of the root
+	// state, 0 if it self-loops. Runs of zero bytes can be skipped
+	// wholesale while at the root, since the root never produces a
+	// match. Using 0/1 bytes (rather than bools) lets the skip loop
+	// OR eight lookups together and take one branch per eight bytes.
+	rootStop [256]byte
+	// rootStopBytes holds the single stop byte when the root leaves its
+	// self-loop on exactly one byte value; the scan loops then skip root
+	// self-loops with SWAR plus the vectorized bytes.IndexByte instead of
+	// the rootStop table. Empty for zero or several stop bytes.
+	rootStopBytes []byte
 
 	bufPool sync.Pool // Pool of *matchBuf
 }
@@ -81,6 +96,58 @@ func newBufPool() sync.Pool {
 	}
 }
 
+// buildRootSkip derives the root self-loop byte set from failTrans.
+// Must be called after failTrans is fully populated.
+func (tr *Trie) buildRootSkip() {
+	tr.rootStopBytes = nil
+	for b := range 256 {
+		if tr.failTrans[rootState][b] != rootState {
+			tr.rootStop[b] = 1
+			tr.rootStopBytes = append(tr.rootStopBytes, byte(b))
+		} else {
+			tr.rootStop[b] = 0
+		}
+	}
+	// With a single stop byte, the scan loops skip root self-loops with
+	// an inline SWAR word scan plus the vectorized bytes.IndexByte (see
+	// walkStopByte). Several stop bytes would need one IndexByte pass per
+	// value, so fall back to the rootStop table.
+	if len(tr.rootStopBytes) > 1 {
+		tr.rootStopBytes = nil
+	}
+}
+
+// swar constants for the zero-byte test: bit 7 of each byte of
+// (w-ones) & ^w & highs is set iff that byte of w is zero.
+const (
+	swarOnes  uint64 = 0x0101010101010101
+	swarHighs uint64 = swarOnes << 7
+)
+
+// skipRootTable returns the position of the first byte at or after i
+// that leaves the root state, or len(input) if there is none, using the
+// rootStop lookup table.
+func (tr *Trie) skipRootTable(input []byte, i int) int {
+	rootStop := &tr.rootStop
+	inputLen := len(input)
+	// Eight lookups are OR-ed together so the common all-skippable
+	// case costs a single branch per eight input bytes.
+	for i+8 <= inputLen {
+		m := rootStop[input[i]] | rootStop[input[i+1]] |
+			rootStop[input[i+2]] | rootStop[input[i+3]] |
+			rootStop[input[i+4]] | rootStop[input[i+5]] |
+			rootStop[input[i+6]] | rootStop[input[i+7]]
+		if m != 0 {
+			break
+		}
+		i += 8
+	}
+	for i < inputLen && rootStop[input[i]] == 0 {
+		i++
+	}
+	return i
+}
+
 // Walk calls this function on any match, giving the end position, length of the matched bytes,
 // and the pattern number.
 type WalkFn func(end, n, pattern uint32) bool
@@ -88,7 +155,81 @@ type WalkFn func(end, n, pattern uint32) bool
 // Walk runs the algorithm on a given output, calling the supplied callback function on every
 // match. The algorithm will terminate if the callback function returns false.
 func (tr *Trie) Walk(input []byte, fn WalkFn) {
-	// Local references to frequently accessed slices.
+	if len(tr.rootStopBytes) == 1 {
+		tr.walkStopByte(input, fn)
+		return
+	}
+	tr.walkTable(input, fn)
+}
+
+// walkStopByte is Walk specialized for tries whose root leaves on a
+// single byte value: the root skip is an inlined SWAR word scan with a
+// vectorized bytes.IndexByte fallback for long gaps.
+func (tr *Trie) walkStopByte(input []byte, fn WalkFn) {
+	failTrans := tr.failTrans
+	dict := tr.dict
+	pattern := tr.pattern
+	dictLink := tr.dictLink
+
+	c := tr.rootStopBytes[0]
+	cc := uint64(c) * swarOnes
+
+	s := rootState
+
+	inputLen := len(input)
+	for i := 0; i < inputLen; i++ {
+		if s == rootState && input[i] != c {
+			// Skip to the next stop byte. Typical gaps are short, so
+			// scan a few words with SWAR first; a bytes.IndexByte call
+			// per gap would be dominated by its setup cost.
+		skip:
+			for k := 0; ; k++ {
+				if i+8 > inputLen {
+					for i < inputLen && input[i] != c {
+						i++
+					}
+					break
+				}
+				w := binary.LittleEndian.Uint64(input[i:]) ^ cc
+				if m := (w - swarOnes) & ^w & swarHighs; m != 0 {
+					i += bits.TrailingZeros64(m) >> 3
+					break
+				}
+				i += 8
+				if k == 3 {
+					j := bytes.IndexByte(input[i:], c)
+					if j < 0 {
+						i = inputLen
+					} else {
+						i += j
+					}
+					break skip
+				}
+			}
+			if i == inputLen {
+				return
+			}
+		}
+
+		s = failTrans[s][input[i]]
+		ds := dict[s]
+		dl := dictLink[s]
+		if ds != 0 || dl != nilState {
+			if ds != 0 && !fn(uint32(i), ds, pattern[s]) {
+				return
+			}
+			for u := dl; u != nilState; u = dictLink[u] {
+				if !fn(uint32(i), dict[u], pattern[u]) {
+					return
+				}
+			}
+		}
+	}
+}
+
+// walkTable is Walk for tries with several root stop bytes, using the
+// rootStop table to skip root self-loops.
+func (tr *Trie) walkTable(input []byte, fn WalkFn) {
 	failTrans := tr.failTrans
 	dict := tr.dict
 	pattern := tr.pattern
@@ -97,9 +238,18 @@ func (tr *Trie) Walk(input []byte, fn WalkFn) {
 	s := rootState
 
 	inputLen := len(input)
-	for i := range inputLen {
-		s = failTrans[s][input[i]]
+	for i := 0; i < inputLen; i++ {
+		if s == rootState {
+			// Fast path: while at the root, skip bytes that self-loop.
+			// The root state never produces a match, so no dict checks
+			// are needed until we leave it.
+			i = tr.skipRootTable(input, i)
+			if i == inputLen {
+				return
+			}
+		}
 
+		s = failTrans[s][input[i]]
 		ds := dict[s]
 		dl := dictLink[s]
 		if ds != 0 || dl != nilState {

--- a/trie.go
+++ b/trie.go
@@ -124,6 +124,11 @@ const (
 	swarHighs uint64 = swarOnes << 7
 )
 
+// rootSkipSampleLen bounds how many root-state bytes walkTable samples,
+// inline, before it commits to whether the root self-loop skip pays off at
+// the input's stop-byte density.
+const rootSkipSampleLen = 4096
+
 // skipRootTable returns the position of the first byte at or after i
 // that leaves the root state, or len(input) if there is none, using the
 // rootStop lookup table.
@@ -238,12 +243,36 @@ func (tr *Trie) walkTable(input []byte, fn WalkFn) {
 	s := rootState
 
 	inputLen := len(input)
+
+	// Root self-loop skip, gated on stop-byte density measured INLINE so an
+	// early-terminating caller (Walk whose callback returns false, as
+	// MatchFirst does) never pays an up-front prefix scan. Begin optimistic;
+	// over the first rootSkipSampleLen root-state bytes, accumulate how many
+	// leave the root (stop bytes). If that density reaches the measured
+	// break-even (~1/16), where the skip machinery costs about as much as the
+	// plain loop, disable it for the remainder. The sampled bytes are ones the
+	// skip reads anyway, so this adds no extra reads and nothing before the
+	// first match.
+	skip := true
+	sample := rootSkipSampleLen
+	var rootBytes, stopBytes int
+
 	for i := 0; i < inputLen; i++ {
-		if s == rootState {
+		if skip && s == rootState {
 			// Fast path: while at the root, skip bytes that self-loop.
 			// The root state never produces a match, so no dict checks
 			// are needed until we leave it.
-			i = tr.skipRootTable(input, i)
+			j := tr.skipRootTable(input, i)
+			if sample > 0 && j < inputLen {
+				// j-i self-looping bytes, then one stop byte at j.
+				rootBytes += j - i + 1
+				stopBytes++
+				sample -= j - i + 1
+				if sample <= 0 && stopBytes*16 >= rootBytes {
+					skip = false
+				}
+			}
+			i = j
 			if i == inputLen {
 				return
 			}

--- a/trie.go
+++ b/trie.go
@@ -129,6 +129,36 @@ const (
 // the input's stop-byte density.
 const rootSkipSampleLen = 4096
 
+// rootSkipSampler decides, from a bounded prefix of root-state runs, whether
+// walkTable's self-loop skip is paying off. Each observed run is `gap`
+// self-loop bytes followed by one stop byte that leaves the root. Once the
+// sample budget is spent, the skip is disabled if the stop-byte density
+// reached the ~1/16 break-even (stopBytes*16 >= rootBytes), where the skip
+// machinery costs about as much as the plain loop. The decision is invisible
+// in Match output — it only toggles an optimization — so it is asserted
+// directly in tests via this type.
+type rootSkipSampler struct {
+	budget    int
+	rootBytes int
+	stopBytes int
+	disabled  bool
+}
+
+// observe records one root-state run of `gap` self-loop bytes ending at a stop
+// byte and reports whether the skip should now be disabled. Runs after the
+// budget is spent are ignored, so the decision is made exactly once.
+func (s *rootSkipSampler) observe(gap int) bool {
+	if s.budget > 0 {
+		s.rootBytes += gap + 1
+		s.stopBytes++
+		s.budget -= gap + 1
+		if s.budget <= 0 && s.stopBytes*16 >= s.rootBytes {
+			s.disabled = true
+		}
+	}
+	return s.disabled
+}
+
 // skipRootTable returns the position of the first byte at or after i
 // that leaves the root state, or len(input) if there is none, using the
 // rootStop lookup table.
@@ -254,8 +284,7 @@ func (tr *Trie) walkTable(input []byte, fn WalkFn) {
 	// skip reads anyway, so this adds no extra reads and nothing before the
 	// first match.
 	skip := true
-	sample := rootSkipSampleLen
-	var rootBytes, stopBytes int
+	sampler := rootSkipSampler{budget: rootSkipSampleLen}
 
 	for i := 0; i < inputLen; i++ {
 		if skip && s == rootState {
@@ -263,14 +292,9 @@ func (tr *Trie) walkTable(input []byte, fn WalkFn) {
 			// The root state never produces a match, so no dict checks
 			// are needed until we leave it.
 			j := tr.skipRootTable(input, i)
-			if sample > 0 && j < inputLen {
+			if j < inputLen && sampler.observe(j-i) {
 				// j-i self-looping bytes, then one stop byte at j.
-				rootBytes += j - i + 1
-				stopBytes++
-				sample -= j - i + 1
-				if sample <= 0 && stopBytes*16 >= rootBytes {
-					skip = false
-				}
+				skip = false
 			}
 			i = j
 			if i == inputLen {


### PR DESCRIPTION
Stacked on #4. The single largest win in the series.

## Insight
On real text the automaton stays in the **root** state for the vast majority of bytes (~93% in the Ibsen benchmark), and the root state never emits a match. Those bytes can be skipped in bulk with no dictionary checks.

## Change
`buildRootSkip` derives, from the transition table, the set of bytes that leave the root state, and picks a skip strategy:
- **Single stop byte** — an inlined SWAR word scan handles short gaps; long gaps escalate to the vectorized `bytes.IndexByte`. (Portable analog of an x86-only SIMD prefilter — this target is arm64.)
- **Zero or several stop bytes** — an 8-wide OR over a 0/1 `rootStop` lookup table: one branch per eight input bytes.

`Walk` is specialized into `walkStopByte` / `walkTable` and dispatches on the stop-byte count. `Match` still runs through `Walk`, so it inherits the skip unchanged.

## Verification
- `go test ./...`, `go test -race -run TestDifferentialRandom ./...` — pass
- `BenchmarkMatchIbsen` vs #4 (0 allocs/op throughout):

  | Input | #4 | this PR | speedup |
  |---|---|---|---|
  | 100 B | 323 ns | 111 ns | 2.9x |
  | 1 KB | 3082 ns | 678 ns | 4.5x |
  | 10 KB | 30.7 µs | 7.50 µs | 4.1x |
  | 100 KB | 319 µs | 128 µs | 2.5x |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Aho–Corasick matching with an adaptive “root skip” optimization to speed up scans in the root state.
  * Added bounded trie decoding via `DecodeWithMaxStates` and `DecodeMaxStates`.
* **Bug Fixes**
  * Decoder now performs stronger validation of stream metadata and rejects corrupt/truncated inputs with clearer “corrupt trie” errors.
  * Root-skip initialization is applied consistently when building/decoding tries.
* **Tests**
  * Added extensive correctness tests covering skip behavior, edge cases, and split boundaries.
* **Chores**
  * Added root-skip benchmarks with real-corpus and density/cardinality sweeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->