### PR TITLE
perf: devirtualized specialized match loops

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -200,6 +200,7 @@ func (tb *TrieBuilder) Build() *Trie {
 		}
 	}
 
+	trie.addOutputFlags()
 	trie.buildRootSkip()
 
 	return trie

--- a/builder.go
+++ b/builder.go
@@ -166,6 +166,15 @@ func (tb *TrieBuilder) Build() *Trie {
 	tb.computeDictLinks()
 
 	numStates := len(tb.states)
+
+	// Packed transitions reserve the high bit for outputFlag (see trie.go),
+	// leaving 31 bits for state ids. Refuse to build a trie whose ids would
+	// collide with the flag. Unreachable in practice: the builder needs
+	// hundreds of bytes per state, so >2^31 states means hundreds of GB.
+	if uint64(numStates) > uint64(stateMask)+1 {
+		panic("ahocorasick: too many states to build trie (max 2^31)")
+	}
+
 	trans := make([][256]uint32, numStates)
 	failLink := make([]uint32, numStates)
 

--- a/stream.go
+++ b/stream.go
@@ -162,6 +162,26 @@ func (dec *decoder) decode() (*Trie, error) {
 			return nil, fmt.Errorf("ahocorasick: corrupt trie: dictLink %d targets state %d, want < %d states", i, v, failTransLen)
 		}
 	}
+	// A dictLink cycle (e.g. 5 -> 7 -> 5) passes the bounds check but
+	// would hang the emit loops, which chase chains until nilState.
+	// Verify every chain terminates; memoizing resolved states keeps the
+	// pass O(states). A terminating chain visits distinct unresolved
+	// states, so a path as long as the table proves a repeat.
+	resolved := make([]bool, dictLinkLen)
+	resolved[nilState] = true
+	path := make([]uint32, 0, 64)
+	for s := range dictLink {
+		path = path[:0]
+		for u := uint32(s); !resolved[u]; u = dictLink[u] {
+			if len(path) == len(dictLink) {
+				return nil, fmt.Errorf("ahocorasick: corrupt trie: dictLink chain from state %d cycles", s)
+			}
+			path = append(path, u)
+		}
+		for _, p := range path {
+			resolved[p] = true
+		}
+	}
 
 	pattern := make([]uint32, patternLen)
 	if err := binary.Read(r, binary.LittleEndian, pattern); err != nil {

--- a/stream.go
+++ b/stream.go
@@ -52,9 +52,16 @@ func (enc *encoder) encode(trie *Trie) error {
 		return err
 	}
 
-	// Flatten and write failTrans
+	// Flatten and write failTrans. In-memory entries carry outputFlag bits
+	// (see addOutputFlags); mask them off so the serialized format stays
+	// plain state ids, compatible with readers that predate the flags.
+	// Decode re-derives the flags.
+	var row [256]uint32
 	for _, arr := range trie.failTrans {
-		if err := binary.Write(w, binary.LittleEndian, arr[:]); err != nil {
+		for i, v := range arr {
+			row[i] = v & stateMask
+		}
+		if err := binary.Write(w, binary.LittleEndian, row[:]); err != nil {
 			return err
 		}
 	}
@@ -132,6 +139,14 @@ func (dec *decoder) decode() (*Trie, error) {
 	if err := binary.Read(r, binary.LittleEndian, flatFailTrans); err != nil {
 		return nil, err
 	}
+	// Transition targets come from an untrusted stream and are used as
+	// indexes by addOutputFlags and the scan loops. Entries must be plain
+	// state ids: in range and without flag bits (Encode strips them).
+	for i, v := range flatFailTrans {
+		if uint64(v) >= failTransLen {
+			return nil, fmt.Errorf("ahocorasick: corrupt trie: transition %d targets state %d, want < %d states", i, v, failTransLen)
+		}
+	}
 	for i := range failTrans {
 		copy(failTrans[i][:], flatFailTrans[i*256:(i+1)*256])
 	}
@@ -139,6 +154,13 @@ func (dec *decoder) decode() (*Trie, error) {
 	dictLink := make([]uint32, dictLinkLen)
 	if err := binary.Read(r, binary.LittleEndian, dictLink); err != nil {
 		return nil, err
+	}
+	// dictLink entries are chased and indexed during matching; bound them
+	// the same way.
+	for i, v := range dictLink {
+		if uint64(v) >= failTransLen {
+			return nil, fmt.Errorf("ahocorasick: corrupt trie: dictLink %d targets state %d, want < %d states", i, v, failTransLen)
+		}
 	}
 
 	pattern := make([]uint32, patternLen)

--- a/stream.go
+++ b/stream.go
@@ -153,6 +153,7 @@ func (dec *decoder) decode() (*Trie, error) {
 		pattern:   pattern,
 		bufPool:   newBufPool(),
 	}
+	trie.addOutputFlags()
 	trie.buildRootSkip()
 	return trie, nil
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -191,3 +191,22 @@ func TestDecodeRejectsOutOfRangeDictLink(t *testing.T) {
 		t.Fatal("expected error for out-of-range dictLink target")
 	}
 }
+
+func TestDecodeRejectsCyclicDictLink(t *testing.T) {
+	for name, dictLink := range map[string][]uint32{
+		"self-loop": {0, 0, 2, 0},
+		"two-cycle": {0, 0, 3, 2},
+	} {
+		failTrans := make([][256]uint32, 4)
+		for s := range failTrans {
+			for b := range 256 {
+				failTrans[s][b] = rootState
+			}
+		}
+
+		_, err := Decode(encodeRaw(t, make([]uint32, 4), failTrans, dictLink, make([]uint32, 4)))
+		if err == nil {
+			t.Fatalf("%s: expected error for cyclic dictLink chain", name)
+		}
+	}
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,6 +2,8 @@ package ahocorasick
 
 import (
 	"bytes"
+	"compress/gzip"
+	"encoding/binary"
 	"fmt"
 	"os"
 	"testing"
@@ -80,5 +82,112 @@ func TestReadAndWriteTrie(t *testing.T) {
 
 	if len(matches) != 3 {
 		t.Errorf("expected 3 matches, got %d", len(matches))
+	}
+}
+
+// encodeRaw writes a trie stream from raw tables, bypassing Encode's
+// flag masking, so tests can construct corrupt payloads.
+func encodeRaw(t *testing.T, dict []uint32, failTrans [][256]uint32, dictLink, pattern []uint32) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	lens := []uint64{uint64(len(dict)), uint64(len(failTrans)), uint64(len(dictLink)), uint64(len(pattern))}
+	for _, n := range lens {
+		if err := binary.Write(w, binary.LittleEndian, n); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := binary.Write(w, binary.LittleEndian, dict); err != nil {
+		t.Fatal(err)
+	}
+	for _, arr := range failTrans {
+		if err := binary.Write(w, binary.LittleEndian, arr[:]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := binary.Write(w, binary.LittleEndian, dictLink); err != nil {
+		t.Fatal(err)
+	}
+	if err := binary.Write(w, binary.LittleEndian, pattern); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return &buf
+}
+
+// TestEncodeStripsOutputFlags verifies the serialized format stays plain
+// state ids: the in-memory outputFlag bits must never reach the stream.
+func TestEncodeStripsOutputFlags(t *testing.T) {
+	trie := NewTrieBuilder().AddStrings([]string{"or", "amet"}).Build()
+
+	var buf bytes.Buffer
+	if err := Encode(&buf, trie); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := gzip.NewReader(&buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	var lens [4]uint64
+	for i := range lens {
+		if err := binary.Read(r, binary.LittleEndian, &lens[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	dict := make([]uint32, lens[0])
+	if err := binary.Read(r, binary.LittleEndian, dict); err != nil {
+		t.Fatal(err)
+	}
+	flat := make([]uint32, lens[1]*256)
+	if err := binary.Read(r, binary.LittleEndian, flat); err != nil {
+		t.Fatal(err)
+	}
+	for i, v := range flat {
+		if v&outputFlag != 0 {
+			t.Fatalf("serialized transition %d carries outputFlag: %#x", i, v)
+		}
+	}
+}
+
+func TestDecodeRejectsOutOfRangeTransition(t *testing.T) {
+	failTrans := make([][256]uint32, 2)
+	for b := range 256 {
+		failTrans[1][b] = rootState
+	}
+	failTrans[1][0] = 2 // out of range: valid states are 0 and 1
+
+	_, err := Decode(encodeRaw(t, make([]uint32, 2), failTrans, make([]uint32, 2), make([]uint32, 2)))
+	if err == nil {
+		t.Fatal("expected error for out-of-range transition target")
+	}
+}
+
+func TestDecodeRejectsFlaggedTransition(t *testing.T) {
+	failTrans := make([][256]uint32, 2)
+	for b := range 256 {
+		failTrans[1][b] = rootState
+	}
+	failTrans[1][0] = outputFlag | rootState // stray flag bit
+
+	_, err := Decode(encodeRaw(t, make([]uint32, 2), failTrans, make([]uint32, 2), make([]uint32, 2)))
+	if err == nil {
+		t.Fatal("expected error for transition carrying a flag bit")
+	}
+}
+
+func TestDecodeRejectsOutOfRangeDictLink(t *testing.T) {
+	failTrans := make([][256]uint32, 2)
+	for b := range 256 {
+		failTrans[1][b] = rootState
+	}
+
+	_, err := Decode(encodeRaw(t, make([]uint32, 2), failTrans, []uint32{0, 7}, make([]uint32, 2)))
+	if err == nil {
+		t.Fatal("expected error for out-of-range dictLink target")
 	}
 }

--- a/trie.go
+++ b/trie.go
@@ -10,6 +10,13 @@ import (
 const (
 	rootState uint32 = 1
 	nilState  uint32 = 0
+
+	// outputFlag is set on a failTrans entry when the target state emits
+	// at least one match (dict or dictLink). It rides along with the
+	// transition load, so the common no-match case needs no extra memory
+	// accesses. stateMask recovers the state id.
+	outputFlag uint32 = 1 << 31
+	stateMask  uint32 = outputFlag - 1
 )
 
 // Trie represents a trie of patterns with extra links as per the Aho-Corasick algorithm.
@@ -19,6 +26,11 @@ type Trie struct {
 	dict     []uint32
 	pattern  []uint32
 	dictLink []uint32
+
+	// dictPat[s] packs pattern[s] (high 32 bits) and dict[s] (low 32
+	// bits) so the emit path fetches both with a single load from one
+	// cache line.
+	dictPat []uint64
 
 	// rootStop[b] is 1 if byte b moves the automaton out of the root
 	// state, 0 if it self-loops. Runs of zero bytes can be skipped
@@ -38,13 +50,13 @@ type Trie struct {
 // matchBuf holds the per-call scratch for Match, recycled through a
 // pool: the returned buffer is acquired with one Get and released with
 // one Put via ReleaseMatches. During the scan, matches are recorded as
-// raw integer pairs (end position, and pattern id packed with match
-// length); appends of plain integers carry no pointers, so they stay off
-// the GC write-barrier path. The Match structs and the returned pointer
-// slice are materialized in one pass afterwards, when the final count is
-// known, so the arena never reallocates under live pointers.
+// raw integer pairs (end position, packed dictPat); appends of plain
+// integers carry no pointers, so they stay off the GC write-barrier
+// path. The Match structs and the returned pointer slice are
+// materialized in one pass afterwards, when the final count is known, so
+// the arena never reallocates under live pointers.
 type matchBuf struct {
-	raw   []uint64 // pairs: end position, packed pattern+length
+	raw   []uint64 // pairs: end position, dictPat
 	ptrs  []*Match
 	arena []Match
 }
@@ -96,12 +108,35 @@ func newBufPool() sync.Pool {
 	}
 }
 
+// addOutputFlags sets outputFlag on every transition whose target state
+// emits at least one match, and builds the packed dictPat array.
+// Idempotent; must be called after failTrans, dict, and dictLink are
+// fully populated.
+func (tr *Trie) addOutputFlags() {
+	var emits = make([]bool, len(tr.dict))
+	for s := range emits {
+		emits[s] = tr.dict[s] != 0 || tr.dictLink[s] != nilState
+	}
+	for s := range tr.failTrans {
+		for b := range 256 {
+			if emits[tr.failTrans[s][b]&stateMask] {
+				tr.failTrans[s][b] |= outputFlag
+			}
+		}
+	}
+
+	tr.dictPat = make([]uint64, len(tr.dict))
+	for s := range tr.dict {
+		tr.dictPat[s] = uint64(tr.pattern[s])<<32 | uint64(tr.dict[s])
+	}
+}
+
 // buildRootSkip derives the root self-loop byte set from failTrans.
 // Must be called after failTrans is fully populated.
 func (tr *Trie) buildRootSkip() {
 	tr.rootStopBytes = nil
 	for b := range 256 {
-		if tr.failTrans[rootState][b] != rootState {
+		if tr.failTrans[rootState][b]&stateMask != rootState {
 			tr.rootStop[b] = 1
 			tr.rootStopBytes = append(tr.rootStopBytes, byte(b))
 		} else {
@@ -172,8 +207,7 @@ func (tr *Trie) Walk(input []byte, fn WalkFn) {
 // vectorized bytes.IndexByte fallback for long gaps.
 func (tr *Trie) walkStopByte(input []byte, fn WalkFn) {
 	failTrans := tr.failTrans
-	dict := tr.dict
-	pattern := tr.pattern
+	dictPat := tr.dictPat
 	dictLink := tr.dictLink
 
 	c := tr.rootStopBytes[0]
@@ -216,15 +250,15 @@ func (tr *Trie) walkStopByte(input []byte, fn WalkFn) {
 			}
 		}
 
-		s = failTrans[s][input[i]]
-		ds := dict[s]
-		dl := dictLink[s]
-		if ds != 0 || dl != nilState {
-			if ds != 0 && !fn(uint32(i), ds, pattern[s]) {
+		v := failTrans[s][input[i]]
+		s = v & stateMask
+		if v&outputFlag != 0 {
+			if dp := dictPat[s]; uint32(dp) != 0 && !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
 				return
 			}
-			for u := dl; u != nilState; u = dictLink[u] {
-				if !fn(uint32(i), dict[u], pattern[u]) {
+			for u := dictLink[s]; u != nilState; u = dictLink[u] {
+				dp := dictPat[u]
+				if !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
 					return
 				}
 			}
@@ -236,8 +270,7 @@ func (tr *Trie) walkStopByte(input []byte, fn WalkFn) {
 // rootStop table to skip root self-loops.
 func (tr *Trie) walkTable(input []byte, fn WalkFn) {
 	failTrans := tr.failTrans
-	dict := tr.dict
-	pattern := tr.pattern
+	dictPat := tr.dictPat
 	dictLink := tr.dictLink
 
 	s := rootState
@@ -278,15 +311,15 @@ func (tr *Trie) walkTable(input []byte, fn WalkFn) {
 			}
 		}
 
-		s = failTrans[s][input[i]]
-		ds := dict[s]
-		dl := dictLink[s]
-		if ds != 0 || dl != nilState {
-			if ds != 0 && !fn(uint32(i), ds, pattern[s]) {
+		v := failTrans[s][input[i]]
+		s = v & stateMask
+		if v&outputFlag != 0 {
+			if dp := dictPat[s]; uint32(dp) != 0 && !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
 				return
 			}
-			for u := dl; u != nilState; u = dictLink[u] {
-				if !fn(uint32(i), dict[u], pattern[u]) {
+			for u := dictLink[s]; u != nilState; u = dictLink[u] {
+				dp := dictPat[u]
+				if !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
 					return
 				}
 			}
@@ -299,13 +332,7 @@ func (tr *Trie) Match(input []byte) []*Match {
 	buf := tr.bufPool.Get().(*matchBuf)
 	buf.reset()
 
-	// Record each match as a raw (end position, packed pattern+length)
-	// pair. Integer appends carry no pointers, so the scan never touches
-	// the GC write-barrier path.
-	tr.Walk(input, func(end, n, pattern uint32) bool {
-		buf.raw = append(buf.raw, uint64(end), uint64(pattern)<<32|uint64(n))
-		return true
-	})
+	tr.matchSeq(input, buf)
 
 	if len(buf.raw) == 0 {
 		tr.bufPool.Put(buf)
@@ -321,6 +348,121 @@ func (tr *Trie) Match(input []byte) []*Match {
 	// callers that hold one match long-term should copy its fields.
 	buf.ptrs[0].buf = buf
 	return buf.ptrs
+}
+
+// matchSeq scans input sequentially into buf.
+func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
+	if len(tr.rootStopBytes) == 1 {
+		tr.matchStopByte(input, buf)
+	} else {
+		tr.matchTable(input, buf)
+	}
+}
+
+// matchStopByte is the Match specialization of walkStopByte: matches are
+// appended straight to buf, avoiding an indirect callback call per match.
+func (tr *Trie) matchStopByte(input []byte, buf *matchBuf) {
+	failTrans := tr.failTrans
+	dictPat := tr.dictPat
+	dictLink := tr.dictLink
+
+	c := tr.rootStopBytes[0]
+	cc := uint64(c) * swarOnes
+
+	s := rootState
+
+	inputLen := len(input)
+	for i := 0; i < inputLen; i++ {
+		if s == rootState && input[i] != c {
+			// See walkStopByte for the skip strategy.
+		skip:
+			for k := 0; ; k++ {
+				if i+8 > inputLen {
+					for i < inputLen && input[i] != c {
+						i++
+					}
+					break
+				}
+				w := binary.LittleEndian.Uint64(input[i:]) ^ cc
+				if m := (w - swarOnes) & ^w & swarHighs; m != 0 {
+					i += bits.TrailingZeros64(m) >> 3
+					break
+				}
+				i += 8
+				if k == 3 {
+					j := bytes.IndexByte(input[i:], c)
+					if j < 0 {
+						i = inputLen
+					} else {
+						i += j
+					}
+					break skip
+				}
+			}
+			if i == inputLen {
+				return
+			}
+		}
+
+		v := failTrans[s][input[i]]
+		s = v & stateMask
+		if v&outputFlag != 0 {
+			if dp := dictPat[s]; uint32(dp) != 0 {
+				buf.raw = append(buf.raw, uint64(i), dp)
+			}
+			for u := dictLink[s]; u != nilState; u = dictLink[u] {
+				buf.raw = append(buf.raw, uint64(i), dictPat[u])
+			}
+		}
+	}
+}
+
+// matchTable is the Match specialization of walkTable.
+func (tr *Trie) matchTable(input []byte, buf *matchBuf) {
+	failTrans := tr.failTrans
+	dictPat := tr.dictPat
+	dictLink := tr.dictLink
+
+	s := rootState
+
+	inputLen := len(input)
+
+	// Root self-loop skip gated on stop-byte density measured inline; see
+	// walkTable. Sample the first rootSkipSampleLen root-state bytes, and
+	// disable the skip for the remainder once density reaches ~1/16.
+	skip := true
+	sample := rootSkipSampleLen
+	var rootBytes, stopBytes int
+
+	for i := 0; i < inputLen; i++ {
+		if skip && s == rootState {
+			j := tr.skipRootTable(input, i)
+			if sample > 0 && j < inputLen {
+				// j-i self-looping bytes, then one stop byte at j.
+				rootBytes += j - i + 1
+				stopBytes++
+				sample -= j - i + 1
+				if sample <= 0 && stopBytes*16 >= rootBytes {
+					skip = false
+				}
+			}
+			i = j
+			if i == inputLen {
+				return
+			}
+		}
+
+		v := failTrans[s][input[i]]
+		s = v & stateMask
+		if v&outputFlag != 0 {
+			if dp := dictPat[s]; uint32(dp) != 0 {
+				buf.raw = append(buf.raw, uint64(i), dp)
+			}
+			for u := dictLink[s]; u != nilState; u = dictLink[u] {
+				buf.raw = append(buf.raw, uint64(i), dictPat[u])
+			}
+		}
+	}
 }
 
 // MatchFirst is the same as Match, but returns after first successful match.


### PR DESCRIPTION
Stacked on #5.

## Change
`Match` stops going through the `Walk` callback. `matchSeq` dispatches to `matchStopByte` / `matchTable`, which append raw `(end, dictPat)` pairs directly into the buffer — no indirect call per match.

Two encodings move work into the transition entry so the common (no-match) byte is cheap:
- **Output-emit flag in bit 31 of the transition entry.** A state emits iff `outputFlag` is set on the entry that reached it, so a no-match byte costs one table load and skips the `dict`/`dictLink` probes entirely. `stateMask` recovers the state id.
- **Packed `dictPat[s]`** = `pattern<<32 | length`, one `uint64` from a single cache line — and already in the buffer's recorded `(end, dictPat)` form, so materialization is a straight copy.

`Walk` is updated to the same flag+packed form (callback parity preserved). `addOutputFlags` builds both tables and runs before `buildRootSkip` in `Build` and `decode`.

The specialized loops use plain bounds-checked indexing here; the unsafe-pointer bounds-check elision is a separate follow-up (#PR5).

## Verification
- `go test ./...`, `go test -race -run TestDifferentialRandom ./...` — pass
- `BenchmarkMatchIbsen` vs #5 (0 allocs/op): 100 B 111→90 ns, 1 KB 678→569 ns, 10 KB 7.50→6.35 µs, 100 KB 128→104 µs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Faster match emission using packed per-state output metadata to reduce per-match overhead.
- **Reliability**
  - Added safeguards during trie building and improved finalization of output-related structures.
  - Strengthened decoding validation for malformed payloads, including state-range checks, transition bounds, and dictionary-link cycle detection.
- **Bug Fixes**
  - Ensured serialized trie data strips internal output-marker bits.
- **Tests**
  - Added tests verifying flag stripping and that decoding rejects out-of-range transitions, invalid flagged transitions, out-of-range dictionary links, and cyclic dictionary links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->