### PR TITLE
perf: transition-table layout tuning

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -154,20 +154,34 @@ func (tb *TrieBuilder) LoadStrings(path string) error {
 	return s.Err()
 }
 
-// Build constructs the final optimized Trie structure.
+// Build constructs the final Trie structure.
 // This involves:
-// 1. Computing failure and dictionary links.
-// 2. Converting the state graph into array-based representation.
-// 3. Pre-computing all possible transitions.
-// 4. Setting up object pools for match results.
+//  1. Computing failure and dictionary links.
+//  2. Renumbering states in BFS order so frequently visited (shallow)
+//     states are packed together for cache and TLB locality.
+//  3. Converting the state graph into array-based representation.
+//  4. Pre-computing all possible transitions.
+//  5. Setting up object pools for match results.
 func (tb *TrieBuilder) Build() *Trie {
 	// Compute failure and dictionary links needed for the Aho-Corasick algorithm.
 	tb.computeFailLinks()
 	tb.computeDictLinks()
 
 	numStates := len(tb.states)
-	trans := make([][256]uint32, numStates)
-	failLink := make([]uint32, numStates)
+
+	// Renumber states breadth-first. The automaton spends nearly all
+	// its time in shallow states; giving them adjacent ids packs their
+	// transition rows into a small contiguous prefix of failTrans.
+	newID := make([]uint32, numStates)
+	order := make([]*state, 0, numStates)
+	order = append(order, tb.states[0], tb.root)
+	newID[tb.root.id] = 1
+	for qi := 1; qi < len(order); qi++ {
+		for _, t := range order[qi].trans {
+			newID[t.id] = uint32(len(order))
+			order = append(order, t)
+		}
+	}
 
 	// Initialize the array-based trie structure.
 	trie := &Trie{
@@ -180,28 +194,23 @@ func (tb *TrieBuilder) Build() *Trie {
 	// Set up object pool for match buffer reuse.
 	trie.bufPool = newBufPool()
 
-	// Convert the state graph into arrays.
-	for i, s := range tb.states {
+	// Convert the state graph into arrays using the BFS numbering.
+	for i, s := range order {
 		trie.dict[i] = s.dict
 		trie.pattern[i] = s.pattern
-		for c, t := range s.trans {
-			trans[i][c] = t.id
-		}
-		if s.failLink != nil {
-			failLink[i] = s.failLink.id
-		}
 		if s.dictLink != nil {
-			trie.dictLink[i] = s.dictLink.id
+			trie.dictLink[i] = newID[s.dictLink.id]
 		}
 		// Pre-compute all possible byte transitions for this state.
 		for b := range 256 {
 			c := byte(b)
-			trie.failTrans[i][c] = tb.computeFailTransition(s, c)
+			trie.failTrans[i][c] = newID[tb.computeFailTransition(s, c)]
 		}
 	}
 
 	trie.addOutputFlags()
 	trie.buildRootSkip()
+	trie.setStopEntry()
 
 	return trie
 }

--- a/builder.go
+++ b/builder.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/hex"
 	"os"
+	"slices"
 	"strings"
 )
 
@@ -180,12 +181,26 @@ func (tb *TrieBuilder) Build() *Trie {
 	// Renumber states breadth-first. The automaton spends nearly all
 	// its time in shallow states; giving them adjacent ids packs their
 	// transition rows into a small contiguous prefix of failTrans.
+	//
+	// Children are visited in byte order: trans is a Go map, and ranging
+	// it directly would assign ids in randomized map order, making the
+	// dict/dictLink/failTrans arrays — and therefore Encode output —
+	// differ between builds of the same pattern set. Fixed order keeps
+	// serialized tries reproducible (checksums, cache keys).
 	newID := make([]uint32, numStates)
 	order := make([]*state, 0, numStates)
 	order = append(order, tb.states[0], tb.root)
 	newID[tb.root.id] = 1
+	keys := make([]byte, 0, 256)
 	for qi := 1; qi < len(order); qi++ {
-		for _, t := range order[qi].trans {
+		s := order[qi]
+		keys = keys[:0]
+		for b := range s.trans {
+			keys = append(keys, b)
+		}
+		slices.Sort(keys)
+		for _, b := range keys {
+			t := s.trans[b]
 			newID[t.id] = uint32(len(order))
 			order = append(order, t)
 		}
@@ -218,6 +233,7 @@ func (tb *TrieBuilder) Build() *Trie {
 
 	trie.addOutputFlags()
 	trie.buildRootSkip()
+	trie.buildFailTrans16()
 	trie.setStopEntry()
 
 	return trie

--- a/stream.go
+++ b/stream.go
@@ -234,6 +234,7 @@ func (dec *decoder) decode(maxStates int) (*Trie, error) {
 	// skip); they are recomputed on decode, not stored in the wire format.
 	trie.addOutputFlags()
 	trie.buildRootSkip()
+	trie.buildFailTrans16()
 	trie.setStopEntry()
 	return trie, nil
 }

--- a/stream.go
+++ b/stream.go
@@ -153,7 +153,10 @@ func (dec *decoder) decode() (*Trie, error) {
 		pattern:   pattern,
 		bufPool:   newBufPool(),
 	}
+	// Rebuild the derived acceleration tables (dictPat, failTrans16, root
+	// skip); they are recomputed on decode, not stored in the wire format.
 	trie.addOutputFlags()
 	trie.buildRootSkip()
+	trie.setStopEntry()
 	return trie, nil
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -278,3 +278,32 @@ func TestDecodeTruncatedBeforeFailTrans(t *testing.T) {
 		t.Fatal("expected error for stream truncated before failTrans, got nil")
 	}
 }
+
+// TestEncodeDeterministic verifies that building the same pattern set twice
+// yields byte-identical serialized tries. BFS renumbering in Build visits
+// children in byte order rather than Go map order, so state ids — and thus
+// the encoded dict/dictLink/failTrans arrays — must not vary between runs.
+// Reproducible artifacts matter for checksums and cache keys.
+func TestEncodeDeterministic(t *testing.T) {
+	// Enough branching (shared prefixes, many distinct first bytes) that
+	// randomized map iteration would almost surely produce different ids.
+	patterns := []string{
+		"or", "orb", "orbit", "amet", "ambit", "gravel", "grave",
+		"zebra", "zeal", "quark", "quartz", "night", "nickel",
+		"he", "she", "his", "hers", "hi", "them", "then", "there",
+	}
+
+	var first bytes.Buffer
+	if err := Encode(&first, NewTrieBuilder().AddStrings(patterns).Build()); err != nil {
+		t.Fatal(err)
+	}
+	for run := 1; run < 5; run++ {
+		var again bytes.Buffer
+		if err := Encode(&again, NewTrieBuilder().AddStrings(patterns).Build()); err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(first.Bytes(), again.Bytes()) {
+			t.Fatalf("run %d: encoded trie differs from first build of the same patterns", run)
+		}
+	}
+}

--- a/trie.go
+++ b/trie.go
@@ -49,6 +49,8 @@ type Trie struct {
 	// loops when every state id fits in 15 bits (bit 15 carries the
 	// output flag). Rows are 512B instead of 1KB, halving the cache
 	// footprint of the table the serial dependency chain loads from.
+	// Built only when the single-stop-byte 16-bit matcher can use it
+	// (see buildFailTrans16); nil otherwise.
 	failTrans16 []uint16
 
 	// stopEntry16 is failTrans16[root][stopByte] when there is a single
@@ -142,25 +144,36 @@ func (tr *Trie) addOutputFlags() {
 	for s := range tr.dict {
 		tr.dictPat[s] = uint64(tr.pattern[s])<<32 | uint64(tr.dict[s])
 	}
+}
 
+// buildFailTrans16 builds the half-width transition table, but only when
+// the match loops can actually use it: matchSeq takes the 16-bit path
+// solely through matchStopByte16, which requires every state id to fit in
+// 15 bits AND a single root stop byte. Building it unconditionally would
+// retain 512B per state of dead weight on multi-stop-byte tries (e.g.
+// ~10MB on a 20K-state dictionary with several initial bytes). Must run
+// after addOutputFlags (reads the flag bits) and buildRootSkip (reads
+// rootStopBytes).
+func (tr *Trie) buildFailTrans16() {
 	tr.failTrans16 = nil
-	if len(tr.failTrans) <= 1<<15 {
-		tr.failTrans16 = make([]uint16, len(tr.failTrans)*256)
-		for s := range tr.failTrans {
-			for b := range 256 {
-				v := tr.failTrans[s][b]
-				w := uint16(v & stateMask)
-				if v&outputFlag != 0 {
-					w |= 1 << 15
-				}
-				tr.failTrans16[s<<8+b] = w
+	if len(tr.failTrans) > 1<<15 || len(tr.rootStopBytes) != 1 {
+		return
+	}
+	tr.failTrans16 = make([]uint16, len(tr.failTrans)*256)
+	for s := range tr.failTrans {
+		for b := range 256 {
+			v := tr.failTrans[s][b]
+			w := uint16(v & stateMask)
+			if v&outputFlag != 0 {
+				w |= 1 << 15
 			}
+			tr.failTrans16[s<<8+b] = w
 		}
 	}
 }
 
 // setStopEntry caches the root transition on the single stop byte.
-// Must run after both buildRootSkip and the failTrans16 build.
+// Must run after both buildRootSkip and buildFailTrans16.
 func (tr *Trie) setStopEntry() {
 	tr.stopEntry16 = 0
 	if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 {

--- a/trie.go
+++ b/trie.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"math/bits"
 	"sync"
+	"unsafe"
 )
 
 const (
@@ -43,6 +44,18 @@ type Trie struct {
 	// self-loops with SWAR plus the vectorized bytes.IndexByte instead of
 	// the rootStop table. Empty for zero or several stop bytes.
 	rootStopBytes []byte
+
+	// failTrans16 is a half-width copy of failTrans used by the match
+	// loops when every state id fits in 15 bits (bit 15 carries the
+	// output flag). Rows are 512B instead of 1KB, halving the cache
+	// footprint of the table the serial dependency chain loads from.
+	failTrans16 []uint16
+
+	// stopEntry16 is failTrans16[root][stopByte] when there is a single
+	// stop byte: the root always transitions to the same depth-1 state
+	// on it, so scan loops substitute this constant for the table load
+	// on every root re-entry, cutting a serial L1 access.
+	stopEntry16 uint16
 
 	bufPool sync.Pool // Pool of *matchBuf
 }
@@ -128,6 +141,30 @@ func (tr *Trie) addOutputFlags() {
 	tr.dictPat = make([]uint64, len(tr.dict))
 	for s := range tr.dict {
 		tr.dictPat[s] = uint64(tr.pattern[s])<<32 | uint64(tr.dict[s])
+	}
+
+	tr.failTrans16 = nil
+	if len(tr.failTrans) <= 1<<15 {
+		tr.failTrans16 = make([]uint16, len(tr.failTrans)*256)
+		for s := range tr.failTrans {
+			for b := range 256 {
+				v := tr.failTrans[s][b]
+				w := uint16(v & stateMask)
+				if v&outputFlag != 0 {
+					w |= 1 << 15
+				}
+				tr.failTrans16[s<<8+b] = w
+			}
+		}
+	}
+}
+
+// setStopEntry caches the root transition on the single stop byte.
+// Must run after both buildRootSkip and the failTrans16 build.
+func (tr *Trie) setStopEntry() {
+	tr.stopEntry16 = 0
+	if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 {
+		tr.stopEntry16 = tr.failTrans16[int(rootState)<<8+int(tr.rootStopBytes[0])]
 	}
 }
 
@@ -352,6 +389,10 @@ func (tr *Trie) Match(input []byte) []*Match {
 
 // matchSeq scans input sequentially into buf.
 func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
+	if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 {
+		tr.matchStopByte16(input, buf)
+		return
+	}
 	if len(tr.rootStopBytes) == 1 {
 		tr.matchStopByte(input, buf)
 	} else {
@@ -359,12 +400,90 @@ func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 	}
 }
 
+// matchStopByte16 is matchStopByte on the half-width failTrans16 table.
+// See matchStopByte for why the loads use raw pointer arithmetic and for
+// the offset shifts.
+func (tr *Trie) matchStopByte16(input []byte, buf *matchBuf) {
+	ftBase := unsafe.Pointer(&tr.failTrans16[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
+
+	c := tr.rootStopBytes[0]
+	cc := uint64(c) * swarOnes
+	stopE := uint32(tr.stopEntry16)
+
+	s := rootState
+
+	inputLen := len(input)
+	for i := 0; i < inputLen; i++ {
+		var v uint32
+		if s == rootState {
+			if input[i] != c {
+				// See walkStopByte for the skip strategy.
+			skip:
+				for k := 0; ; k++ {
+					if i+8 > inputLen {
+						for i < inputLen && input[i] != c {
+							i++
+						}
+						break
+					}
+					w := binary.LittleEndian.Uint64(input[i:]) ^ cc
+					if m := (w - swarOnes) & ^w & swarHighs; m != 0 {
+						i += bits.TrailingZeros64(m) >> 3
+						break
+					}
+					i += 8
+					if k == 3 {
+						j := bytes.IndexByte(input[i:], c)
+						if j < 0 {
+							i = inputLen
+						} else {
+							i += j
+						}
+						break skip
+					}
+				}
+				if i == inputLen {
+					return
+				}
+			}
+			// At the root the cursor is on the stop byte, so the
+			// transition is the precomputed constant: no table load
+			// on the serial chain.
+			v = stopE
+		} else {
+			v = uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(s)<<9+uintptr(input[i])<<1)))
+		}
+		s = v &^ (1 << 15)
+		if v&(1<<15) != 0 {
+			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 {
+				buf.raw = append(buf.raw, uint64(i), dp)
+			}
+			for u := *(*uint32)(unsafe.Add(dlBase, uintptr(s)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+				buf.raw = append(buf.raw, uint64(i), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+			}
+		}
+	}
+}
+
 // matchStopByte is the Match specialization of walkStopByte: matches are
 // appended straight to buf, avoiding an indirect callback call per match.
+//
+// The transition and emit loads use raw pointer arithmetic: state ids
+// come from masking a table entry, so the compiler cannot prove them in
+// bounds and would otherwise emit a bounds check on the critical
+// dependency chain. All entries are valid state ids by construction
+// (builder and decoder populate every slot), so the accesses are safe.
+// The offsets are byte offsets into each array: <<10 selects a 1KB
+// failTrans row (256 uint32) and <<2 the byte column within it; <<3
+// indexes a dictPat (uint64) and <<2 a dictLink (uint32). The failTrans16
+// path halves these to <<9 for the 512B row and <<1 for the uint16
+// column.
 func (tr *Trie) matchStopByte(input []byte, buf *matchBuf) {
-	failTrans := tr.failTrans
-	dictPat := tr.dictPat
-	dictLink := tr.dictLink
+	ftBase := unsafe.Pointer(&tr.failTrans[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
 
 	c := tr.rootStopBytes[0]
 	cc := uint64(c) * swarOnes
@@ -404,24 +523,25 @@ func (tr *Trie) matchStopByte(input []byte, buf *matchBuf) {
 			}
 		}
 
-		v := failTrans[s][input[i]]
+		v := *(*uint32)(unsafe.Add(ftBase, uintptr(s)<<10+uintptr(input[i])<<2))
 		s = v & stateMask
 		if v&outputFlag != 0 {
-			if dp := dictPat[s]; uint32(dp) != 0 {
+			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 {
 				buf.raw = append(buf.raw, uint64(i), dp)
 			}
-			for u := dictLink[s]; u != nilState; u = dictLink[u] {
-				buf.raw = append(buf.raw, uint64(i), dictPat[u])
+			for u := *(*uint32)(unsafe.Add(dlBase, uintptr(s)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+				buf.raw = append(buf.raw, uint64(i), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
 			}
 		}
 	}
 }
 
-// matchTable is the Match specialization of walkTable.
+// matchTable is the Match specialization of walkTable. See matchStopByte
+// for why the loads use raw pointer arithmetic.
 func (tr *Trie) matchTable(input []byte, buf *matchBuf) {
-	failTrans := tr.failTrans
-	dictPat := tr.dictPat
-	dictLink := tr.dictLink
+	ftBase := unsafe.Pointer(&tr.failTrans[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
 
 	s := rootState
 
@@ -452,14 +572,14 @@ func (tr *Trie) matchTable(input []byte, buf *matchBuf) {
 			}
 		}
 
-		v := failTrans[s][input[i]]
+		v := *(*uint32)(unsafe.Add(ftBase, uintptr(s)<<10+uintptr(input[i])<<2))
 		s = v & stateMask
 		if v&outputFlag != 0 {
-			if dp := dictPat[s]; uint32(dp) != 0 {
+			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 {
 				buf.raw = append(buf.raw, uint64(i), dp)
 			}
-			for u := dictLink[s]; u != nilState; u = dictLink[u] {
-				buf.raw = append(buf.raw, uint64(i), dictPat[u])
+			for u := *(*uint32)(unsafe.Add(dlBase, uintptr(s)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+				buf.raw = append(buf.raw, uint64(i), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
 			}
 		}
 	}

--- a/trie_test.go
+++ b/trie_test.go
@@ -271,3 +271,28 @@ func readPatterns(path string) ([]string, error) {
 
 	return patterns, nil
 }
+
+// TestFailTrans16Gate verifies the half-width table is built exactly when the
+// 16-bit match path can use it: small trie with a single root stop byte. A
+// multi-stop-byte trie routes through matchTable, which reads the full-width
+// failTrans, so retaining failTrans16 there would be pure dead weight (512B
+// per state).
+func TestFailTrans16Gate(t *testing.T) {
+	// All patterns share the initial byte 'a': one root stop byte.
+	single := NewTrieBuilder().AddStrings([]string{"amet", "ambit", "arc"}).Build()
+	if single.failTrans16 == nil {
+		t.Error("single stop byte, small trie: expected failTrans16 to be built")
+	}
+	if got := single.MatchString("xx amet yy"); len(got) != 1 {
+		t.Errorf("single stop byte: expected 1 match, got %d", len(got))
+	}
+
+	// Distinct initial bytes: several root stop bytes, table path.
+	multi := NewTrieBuilder().AddStrings([]string{"or", "amet", "zebra"}).Build()
+	if multi.failTrans16 != nil {
+		t.Error("multiple stop bytes: expected failTrans16 to be skipped")
+	}
+	if got := multi.MatchString("zebra or amet"); len(got) != 3 {
+		t.Errorf("multiple stop bytes: expected 3 matches, got %d", len(got))
+	}
+}


### PR DESCRIPTION
Stacked on #6. A cluster of locality / access-cost tweaks on the sequential scan; none change output.

- **BFS state renumbering** (builder). Renumber states breadth-first so the shallow, hot states get adjacent ids and their transition rows land in a small contiguous prefix of `failTrans` — better cache/TLB locality.
- **Half-width `failTrans16` table.** When every state id fits in 15 bits, keep a `uint16` copy of the transition table (bit 15 carries the output flag). Rows are **512 B instead of 1 KB**, halving the footprint of the table on the serial dependency chain.
- **Precomputed root-on-stop-byte transition (`stopEntry16`).** At the root the cursor always sits on the single stop byte, so that transition is a constant — substituted for a table load on every root re-entry.
- **Unsafe pointer arithmetic in the match loops.** State ids come from masking a table entry, which the compiler can't prove in-bounds, so it would emit a bounds check on the critical dependency chain. Every entry is a valid state id by construction (builder + decoder populate every slot), so the loads are safe; the offset shifts (`<<10`/`<<9`/`<<3`/`<<2`/`<<1`) are documented on `matchStopByte`.

`matchSeq` prefers `matchStopByte16` when the half-width table exists.

## Verification
- `go test ./...`, `go test -race -run TestDifferentialRandom ./...` — pass
- `BenchmarkMatchIbsen` vs #6 (0 allocs/op): 100 B 90→82 ns, 1 KB 569→510 ns, 10 KB 6.35→5.55 µs, 100 KB 104→95 µs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved pattern-matching speed through optimized transition tables and fast paths for eligible searches.
  * Preserved matching behavior while reducing transition lookup overhead.

* **Reliability**
  * Trie serialization is now deterministic across repeated builds.
  * Added validation for optimized matching conditions and expected match results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->