### PR TITLE
perf: dual-cursor interleaved scan

### DIFF
--- a/dualscan_test.go
+++ b/dualscan_test.go
@@ -1,0 +1,210 @@
+package ahocorasick
+
+// Focused unit tests for the dual-cursor scan internals: scanRange16's
+// [i,to) window and minEmit filter, and matchDualStopByte16's lane-merge
+// boundary at mid. TestRootSkipSplitBoundaries and TestDifferentialRandom
+// cover these end-to-end through Match, but they route through matchSeq's
+// size heuristics; these tests call the internals directly so the
+// invariants stay pinned even if those thresholds change.
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+)
+
+// buildStopByte16Trie builds a trie for patterns and asserts it takes the
+// 16-bit single-stop-byte path that scanRange16 and matchDualStopByte16
+// require.
+func buildStopByte16Trie(t *testing.T, patterns []string) *Trie {
+	t.Helper()
+	tr := NewTrieBuilder().AddStrings(patterns).Build()
+	if tr.failTrans16 == nil || len(tr.rootStopBytes) != 1 {
+		t.Fatalf("test setup: trie must take the 16-bit single-stop-byte path (failTrans16=%v, stop bytes=%d)",
+			tr.failTrans16 != nil, len(tr.rootStopBytes))
+	}
+	return tr
+}
+
+// seqRaw16 returns the raw (end, dictPat) pairs of a full sequential
+// matchStopByte16 scan, the oracle the range/dual scans must reproduce.
+// matchStopByte16 itself is pinned to naiveMatch by the differential and
+// root-skip tests.
+func seqRaw16(tr *Trie, input []byte) []uint64 {
+	buf := new(matchBuf)
+	buf.reset()
+	tr.matchStopByte16(input, buf)
+	return buf.raw
+}
+
+// filterRaw returns the (end, dictPat) pairs whose end satisfies keep.
+func filterRaw(raw []uint64, keep func(end uint64) bool) []uint64 {
+	out := []uint64{}
+	for k := 0; k+1 < len(raw); k += 2 {
+		if keep(raw[k]) {
+			out = append(out, raw[k], raw[k+1])
+		}
+	}
+	return out
+}
+
+// TestScanRange16MinEmit asserts scanRange16 never emits a match ending
+// before minEmit, emits a match ending exactly at minEmit (the filter is
+// >=, not >), and otherwise reproduces the sequential scan restricted to
+// [minEmit, to).
+func TestScanRange16MinEmit(t *testing.T) {
+	patterns := []string{"ab", "abc", "a"}
+	tr := buildStopByte16Trie(t, patterns)
+
+	input := bytesFill(300, 'x')
+	// Matches at the start, sprinkled through the middle, and at the end.
+	for _, pos := range []int{0, 40, 97, 98, 149, 150, 151, 203, 297} {
+		copy(input[pos:], "abc")
+	}
+
+	full := seqRaw16(tr, input)
+	if got := tr.scanRange16(input, 0, len(input), rootState, 0, nil); !slices.Equal(got, full) {
+		t.Fatalf("full-range scanRange16 disagrees with matchStopByte16:\n  got=%v\n want=%v", got, full)
+	}
+	if len(full) == 0 {
+		t.Fatal("test setup: expected matches in input")
+	}
+
+	// 150 is the end of the "a" planted at 150; ends at exactly minEmit
+	// must be kept.
+	for _, minEmit := range []int{0, 1, 41, 150, 152, 205, len(input) - 1, len(input)} {
+		t.Run(fmt.Sprintf("minEmit=%d", minEmit), func(t *testing.T) {
+			got := tr.scanRange16(input, 0, len(input), rootState, minEmit, nil)
+			for k := 0; k+1 < len(got); k += 2 {
+				if got[k] < uint64(minEmit) {
+					t.Fatalf("emitted end %d < minEmit %d", got[k], minEmit)
+				}
+			}
+			want := filterRaw(full, func(end uint64) bool { return end >= uint64(minEmit) })
+			if !slices.Equal(got, want) {
+				t.Fatalf("scanRange16 minEmit=%d:\n  got=%v\n want=%v", minEmit, got, want)
+			}
+		})
+	}
+
+	// Boundary sanity for one case: a match ends exactly at 150, so the
+	// >= filter must retain it.
+	got := tr.scanRange16(input, 0, len(input), rootState, 150, nil)
+	found := false
+	for k := 0; k+1 < len(got); k += 2 {
+		if got[k] == 150 {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("match ending exactly at minEmit was dropped (filter must be >=, not >)")
+	}
+}
+
+// TestScanRange16ToBound asserts the to bound: scanning [0,to) equals the
+// sequential scan restricted to ends < to, for boundaries landing on,
+// before, and after planted match ends.
+func TestScanRange16ToBound(t *testing.T) {
+	patterns := []string{"ab", "abc", "a"}
+	tr := buildStopByte16Trie(t, patterns)
+
+	input := bytesFill(300, 'x')
+	for _, pos := range []int{0, 40, 149, 150, 151, 297} {
+		copy(input[pos:], "abc")
+	}
+	full := seqRaw16(tr, input)
+
+	for _, to := range []int{0, 1, 42, 150, 151, 152, 299, len(input)} {
+		t.Run(fmt.Sprintf("to=%d", to), func(t *testing.T) {
+			got := tr.scanRange16(input, 0, to, rootState, 0, nil)
+			want := filterRaw(full, func(end uint64) bool { return end < uint64(to) })
+			if !slices.Equal(got, want) {
+				t.Fatalf("scanRange16 to=%d:\n  got=%v\n want=%v", to, got, want)
+			}
+		})
+	}
+}
+
+// dualRaw16 runs matchDualStopByte16 and returns the merged raw pairs.
+func dualRaw16(tr *Trie, input []byte) []uint64 {
+	buf := new(matchBuf)
+	buf.reset()
+	tr.matchDualStopByte16(input, buf)
+	return buf.raw
+}
+
+// checkDualAgainstSeq asserts the dual-cursor scan's merged output equals
+// the sequential scan exactly (no overlap, gap, or reorder at mid) and
+// that the output is partitioned at mid: a prefix of ends < mid (lane A)
+// followed by a suffix of ends >= mid (lane B).
+func checkDualAgainstSeq(t *testing.T, tr *Trie, input []byte) {
+	t.Helper()
+	got := dualRaw16(tr, input)
+	want := seqRaw16(tr, input)
+	if !slices.Equal(got, want) {
+		t.Fatalf("dual scan disagrees with sequential scan (len %d vs %d):\n  got=%v\n want=%v",
+			len(got)/2, len(want)/2, got, want)
+	}
+
+	mid := uint64(len(input) / 2)
+	inB := false
+	for k := 0; k+1 < len(got); k += 2 {
+		if got[k] >= mid {
+			inB = true
+		} else if inB {
+			t.Fatalf("end %d < mid %d after a lane-B entry: output not partitioned at mid", got[k], mid)
+		}
+	}
+}
+
+// TestDualStopByte16LaneMergeBoundary plants matches at every offset
+// within maxLen of mid — including ones entirely inside lane B's warm-up
+// overlap [mid-maxLen+1, mid), which lane B walks but must not emit — plus
+// the input edges, and asserts the merged dual output is exactly the
+// sequential scan. Odd sizes exercise the mid = len/2 floor.
+func TestDualStopByte16LaneMergeBoundary(t *testing.T) {
+	patterns := []string{"ab", "abc", "a"}
+	tr := buildStopByte16Trie(t, patterns)
+	maxLen := int(tr.maxLen)
+
+	for _, sz := range []int{1024, 1101, 2048, 4097} {
+		t.Run(fmt.Sprintf("sz=%d", sz), func(t *testing.T) {
+			input := bytesFill(sz, 'x')
+			mid := sz / 2
+			for d := -2 * maxLen; d <= 2*maxLen; d++ {
+				if pos := mid + d; pos >= 0 && pos+3 <= sz {
+					copy(input[pos:], "abc")
+				}
+			}
+			copy(input[0:], "abc")
+			copy(input[sz-3:], "abc")
+			checkDualAgainstSeq(t, tr, input)
+		})
+	}
+}
+
+// TestDualStopByte16UnevenLanes forces the two lanes to progress at very
+// different rates so the interleaved loop exits with one lane far from its
+// boundary and scanRange16 finishes a large remainder: a dense half is all
+// stop bytes (one transition per byte, many emits) while a sparse half is
+// all self-loop filler (SWAR skip, ~8 bytes per step).
+func TestDualStopByte16UnevenLanes(t *testing.T) {
+	patterns := []string{"ab", "abc", "a"}
+	tr := buildStopByte16Trie(t, patterns)
+
+	const sz = 4096
+	t.Run("dense_A_sparse_B", func(t *testing.T) {
+		input := bytesFill(sz, 'x')
+		for i := 0; i < sz/2; i++ {
+			input[i] = 'a' // lane A: every byte is a stop byte
+		}
+		checkDualAgainstSeq(t, tr, input)
+	})
+	t.Run("sparse_A_dense_B", func(t *testing.T) {
+		input := bytesFill(sz, 'x')
+		for i := sz / 2; i < sz; i++ {
+			input[i] = 'a' // lane B: every byte is a stop byte
+		}
+		checkDualAgainstSeq(t, tr, input)
+	})
+}

--- a/trie.go
+++ b/trie.go
@@ -76,6 +76,7 @@ type Trie struct {
 // known, so the arena never reallocates under live pointers.
 type matchBuf struct {
 	raw   []uint64 // pairs: end position, dictPat
+	raw2  []uint64 // second lane of the dual-cursor scan
 	ptrs  []*Match
 	arena []Match
 }
@@ -83,6 +84,7 @@ type matchBuf struct {
 // reset prepares the buffer for reuse, keeping all allocated capacity.
 func (b *matchBuf) reset() {
 	b.raw = b.raw[:0]
+	b.raw2 = b.raw2[:0]
 	b.ptrs = b.ptrs[:0]
 }
 
@@ -381,8 +383,9 @@ const parallelChunk = 8 << 10
 // Match runs the Aho-Corasick string-search algorithm on a byte input.
 func (tr *Trie) Match(input []byte) []*Match {
 	if len(input) >= 2*parallelChunk {
-		// More workers mainly adds wakeup and steal latency; cap at 8 to
-		// keep each chunk large enough to amortize goroutine startup.
+		// Workers dual-scan their chunks, so more of them mainly adds
+		// wakeup and steal latency; cap at 8 to keep each chunk large
+		// enough to amortize goroutine startup.
 		if p := min(runtime.GOMAXPROCS(0), len(input)/parallelChunk, 8); p > 1 {
 			return tr.matchParallel(input, p)
 		}
@@ -409,9 +412,19 @@ func (tr *Trie) Match(input []byte) []*Match {
 	return buf.ptrs
 }
 
+// dualThreshold is the minimum input size for the dual-cursor scan.
+const dualThreshold = 1024
+
 // matchSeq scans input sequentially into buf.
 func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 	if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 {
+		// Dual-scan only when the maxLen-1 bytes lane B re-scans are a
+		// small fraction of a half; otherwise the redundant overlap work
+		// outweighs the overlapped load latency.
+		if len(input) >= dualThreshold && int(tr.maxLen)*4 < len(input)/2 {
+			tr.matchDualStopByte16(input, buf)
+			return
+		}
 		tr.matchStopByte16(input, buf)
 		return
 	}
@@ -420,6 +433,161 @@ func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 	} else {
 		tr.matchTable(input, buf)
 	}
+}
+
+// scanRange16 runs the stop-byte automaton over input[i:to), starting in
+// state s, appending matches that end at or after minEmit to raw, which
+// is returned. Positions are absolute into input; the SWAR skip may read
+// (but not emit) past to. Loads use raw pointer arithmetic; see
+// matchStopByte.
+func (tr *Trie) scanRange16(input []byte, i, to int, s uint32, minEmit int, raw []uint64) []uint64 {
+	ftBase := unsafe.Pointer(&tr.failTrans16[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
+
+	c := tr.rootStopBytes[0]
+	cc := uint64(c) * swarOnes
+
+	inputLen := len(input)
+	for ; i < to; i++ {
+		if s == rootState && input[i] != c {
+		skip:
+			for k := 0; ; k++ {
+				if i+8 > inputLen {
+					for i < inputLen && input[i] != c {
+						i++
+					}
+					break
+				}
+				w := binary.LittleEndian.Uint64(input[i:]) ^ cc
+				if m := (w - swarOnes) & ^w & swarHighs; m != 0 {
+					i += bits.TrailingZeros64(m) >> 3
+					break
+				}
+				i += 8
+				if k == 3 {
+					j := bytes.IndexByte(input[i:], c)
+					if j < 0 {
+						i = inputLen
+					} else {
+						i += j
+					}
+					break skip
+				}
+			}
+			if i >= to {
+				return raw
+			}
+		}
+
+		v := uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(s)<<9+uintptr(input[i])<<1)))
+		s = v &^ (1 << 15)
+		if v&(1<<15) != 0 && i >= minEmit {
+			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 {
+				raw = append(raw, uint64(i), dp)
+			}
+			for u := *(*uint32)(unsafe.Add(dlBase, uintptr(s)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+				raw = append(raw, uint64(i), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+			}
+		}
+	}
+	return raw
+}
+
+// matchDualStopByte16 scans the two halves of input with two independent
+// automaton cursors interleaved in one loop. The state-transition load
+// chain is the serial bottleneck of a single scan; two chains overlap
+// their L1 latencies. Lane B starts maxLen-1 bytes before the midpoint
+// (see matchParallel for why that overlap suffices) and emits only
+// matches ending at or after the midpoint, so rawA followed by rawB is
+// exactly a sequential scan's output. Loads use raw pointer arithmetic;
+// see matchStopByte.
+func (tr *Trie) matchDualStopByte16(input []byte, buf *matchBuf) {
+	ftBase := unsafe.Pointer(&tr.failTrans16[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
+
+	c := tr.rootStopBytes[0]
+	cc := uint64(c) * swarOnes
+
+	inputLen := len(input)
+	mid := inputLen / 2
+	startB := max(mid-int(tr.maxLen)+1, 0)
+
+	stopE := uint32(tr.stopEntry16)
+
+	sA, sB := rootState, rootState
+	iA, iB := 0, startB
+	rawA, rawB := buf.raw, buf.raw2
+
+	for iA < mid && iB < inputLen {
+		// Lane A: one bounded step (a transition, or up to 8 skipped bytes).
+		if sA == rootState && input[iA] != c {
+			if iA+8 <= inputLen {
+				w := binary.LittleEndian.Uint64(input[iA:]) ^ cc
+				if m := (w - swarOnes) & ^w & swarHighs; m != 0 {
+					iA += bits.TrailingZeros64(m) >> 3
+				} else {
+					iA += 8
+				}
+			} else {
+				iA++
+			}
+		} else {
+			v := stopE
+			if sA != rootState {
+				v = uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(sA)<<9+uintptr(input[iA])<<1)))
+			}
+			sA = v &^ (1 << 15)
+			if v&(1<<15) != 0 {
+				if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(sA)<<3)); uint32(dp) != 0 {
+					rawA = append(rawA, uint64(iA), dp)
+				}
+				for u := *(*uint32)(unsafe.Add(dlBase, uintptr(sA)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+					rawA = append(rawA, uint64(iA), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+				}
+			}
+			iA++
+		}
+
+		// Lane B: same step shape.
+		if sB == rootState && input[iB] != c {
+			if iB+8 <= inputLen {
+				w := binary.LittleEndian.Uint64(input[iB:]) ^ cc
+				if m := (w - swarOnes) & ^w & swarHighs; m != 0 {
+					iB += bits.TrailingZeros64(m) >> 3
+				} else {
+					iB += 8
+				}
+			} else {
+				iB++
+			}
+		} else {
+			v := stopE
+			if sB != rootState {
+				v = uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(sB)<<9+uintptr(input[iB])<<1)))
+			}
+			sB = v &^ (1 << 15)
+			if v&(1<<15) != 0 && iB >= mid {
+				if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(sB)<<3)); uint32(dp) != 0 {
+					rawB = append(rawB, uint64(iB), dp)
+				}
+				for u := *(*uint32)(unsafe.Add(dlBase, uintptr(sB)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+					rawB = append(rawB, uint64(iB), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+				}
+			}
+			iB++
+		}
+	}
+
+	// Finish whichever lane has input left.
+	rawA = tr.scanRange16(input, iA, mid, sA, 0, rawA)
+	rawB = tr.scanRange16(input, iB, inputLen, sB, mid, rawB)
+
+	// Concatenate: lane A ends < mid, lane B ends >= mid, so order is
+	// exactly the sequential scan's.
+	buf.raw = append(rawA, rawB...)
+	buf.raw2 = rawB[:0]
 }
 
 // matchStopByte16 is matchStopByte on the half-width failTrans16 table.

--- a/trie.go
+++ b/trie.go
@@ -447,6 +447,7 @@ func (tr *Trie) scanRange16(input []byte, i, to int, s uint32, minEmit int, raw 
 
 	c := tr.rootStopBytes[0]
 	cc := uint64(c) * swarOnes
+	stopE := uint32(tr.stopEntry16)
 
 	inputLen := len(input)
 	for ; i < to; i++ {
@@ -480,7 +481,13 @@ func (tr *Trie) scanRange16(input []byte, i, to int, s uint32, minEmit int, raw 
 			}
 		}
 
-		v := uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(s)<<9+uintptr(input[i])<<1)))
+		// At the root the cursor is on the stop byte (the skip above
+		// guarantees input[i] == c), so the transition is the
+		// precomputed constant; see matchStopByte16.
+		v := stopE
+		if s != rootState {
+			v = uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(s)<<9+uintptr(input[i])<<1)))
+		}
 		s = v &^ (1 << 15)
 		if v&(1<<15) != 0 && i >= minEmit {
 			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 {


### PR DESCRIPTION
Stacked on #8. Final PR in the series.

## Change
The state-transition load chain is the serial bottleneck of a single scan. This runs **two independent automaton cursors** over the two halves of the input, interleaved in one goroutine, so their L1-load latencies overlap.

- Lane A scans `[0, mid)`.
- Lane B starts `maxLen-1` bytes before `mid` and emits **only** matches ending at or after `mid` — same overlap argument as `matchParallel` (#8). So `rawA` followed by `rawB` is exactly a sequential scan's output.
- The interleaved loop takes one bounded step per lane per iteration; `scanRange16` finishes whichever lane still has input.

Gated in `matchSeq`: only on the `failTrans16` single-stop-byte path, for inputs $\geq$ 1024 bytes, and only when `maxLen-1` is a small fraction of a half (`maxLen*4 < len/2`), so the overlap re-scan is cheaper than the latency it hides.

## Verification
- `go test ./...`, `go test -race ./...` — pass (differential fuzz covers the dual-cursor sizes and confirms byte-identical output + ordering)
- Full-stack `BenchmarkMatchIbsen` vs baseline (0 allocs on the sequential sizes):

  | Input | Baseline | Final | Speedup |
  |---|---|---|---|
  | 100 B | 513 ns | 85 ns | 6.1x |
  | 1 KB | 4.18 µs | 495 ns | 8.4x |
  | 10 KB | 43.1 µs | 5.10 µs | 8.4x |
  | 100 KB | 419 µs | 53.2 µs | 7.9x |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved scanning performance for large inputs through optimized dual-cursor processing.
  - Preserved match ordering and results while processing eligible searches in parallel.

- **Bug Fixes**
  - Ensured matches remain correct across scan boundaries and uneven processing paths.
  - Added safeguards for bounded scans and minimum match filtering.

- **Tests**
  - Added coverage validating dual scanning against sequential results across varied input patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->