### PR TITLE
perf: dispatch the dual-cursor scan by sampled stop-byte density

### DIFF
--- a/chainheavy_test.go
+++ b/chainheavy_test.go
@@ -121,7 +121,14 @@ func TestChainHeavyMidChainWindows(t *testing.T) {
 func TestDifferentialLongPatternDual(t *testing.T) {
 	pats := buildLongPatterns(64, 100)
 	tr := buildStopByte16Trie(t, pats)
-	in := concat(pats, 32<<10)
+	// Sized inside the serial window: big enough for chainHeavy's 4KB
+	// floor, below Match's 2*parallelChunk parallel dispatch, so the
+	// scan is guaranteed to go matchSeq -> chainHeavy -> dual-cursor
+	// regardless of GOMAXPROCS.
+	in := concat(pats, 12<<10)
+	if len(in) >= 2*parallelChunk {
+		t.Fatal("test setup: input must stay below the parallel dispatch threshold")
+	}
 	if !tr.chainHeavy(in) {
 		t.Fatal("test setup: input must take the chain-heavy dual path")
 	}

--- a/chainheavy_test.go
+++ b/chainheavy_test.go
@@ -1,0 +1,115 @@
+package ahocorasick
+
+// Tests for the chain-occupancy dispatch gate (chainHeavy): the second
+// dual-cursor routing signal for inputs whose stop-byte density is low
+// but whose bytes are almost all serial transition loads (long-pattern
+// excursions). looksDense alone misses that regime; these tests pin the
+// routing on both sides of the occupancy boundary and cross-check the
+// rescued path against the naive reference.
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// buildLongPatterns returns npat patterns of length plen, all starting
+// with 'q' (single root stop byte) and avoiding 'q' elsewhere, so a
+// concatenation has stop-byte density 1/plen while keeping the scanner
+// in-chain on nearly every byte.
+func buildLongPatterns(plen, npat int) []string {
+	rng := rand.New(rand.NewSource(42))
+	pats := make([]string, npat)
+	for i := range pats {
+		b := make([]byte, plen)
+		b[0] = 'q'
+		for j := 1; j < plen; j++ {
+			b[j] = byte('a' + rng.Intn(16))
+			if b[j] == 'q' {
+				b[j] = 'r'
+			}
+		}
+		pats[i] = string(b)
+	}
+	return pats
+}
+
+// concat repeats patterns round-robin until the result reaches size.
+func concat(patterns []string, size int) []byte {
+	var in []byte
+	for i := 0; len(in) < size; i++ {
+		in = append(in, patterns[i%len(patterns)]...)
+	}
+	return in[:size]
+}
+
+func TestChainHeavyLongPatternInput(t *testing.T) {
+	for _, plen := range []int{32, 64, 100} {
+		pats := buildLongPatterns(plen, 200)
+		tr := buildStopByte16Trie(t, pats)
+		in := concat(pats, 64<<10)
+
+		// The workload this gate exists for: ~1-3% stop-byte density,
+		// ~100% chain occupancy. looksDense must reject it (density is
+		// below dualDenseThreshold) and chainHeavy must rescue it.
+		if looksDense(in, tr.rootStopBytes[0]) {
+			t.Fatalf("plen=%d: looksDense=true; input no longer exercises the low-density regime", plen)
+		}
+		if !tr.chainHeavy(in) {
+			t.Errorf("plen=%d: chainHeavy=false for concatenated long patterns", plen)
+		}
+	}
+}
+
+func TestChainHeavySkipFriendlyInput(t *testing.T) {
+	pats := buildLongPatterns(32, 200)
+	tr := buildStopByte16Trie(t, pats)
+
+	// Filler-separated occurrences: every fourth 32-byte pattern is a
+	// 96-byte 'x' run the root skip leaps over (~25% occupancy), the
+	// regime where the single cursor's inline skip wins.
+	var in []byte
+	for i := 0; len(in) < 64<<10; i++ {
+		in = append(in, pats[i%len(pats)]...)
+		in = append(in, bytesFill(96, 'x')...)
+	}
+	in = in[:64<<10]
+	if tr.chainHeavy(in) {
+		t.Error("chainHeavy=true for skip-friendly filler input")
+	}
+
+	// No stop byte at all: the skip budget must exhaust immediately.
+	if tr.chainHeavy(bytesFill(64<<10, 'x')) {
+		t.Error("chainHeavy=true for input without stop bytes")
+	}
+
+	// At or below 4KB the sample would be a significant fraction of the
+	// scan, so the gate stays closed regardless of content.
+	if tr.chainHeavy(concat(pats, 4096)) {
+		t.Error("chainHeavy=true for 4KB input; small inputs must not pay the sample walk")
+	}
+}
+
+// TestDifferentialLongPatternDual cross-checks Match against the naive
+// reference on the chain-heavy input that chainHeavy routes to the
+// dual-cursor scan, so the rescued dispatch path stays correct end to end.
+func TestDifferentialLongPatternDual(t *testing.T) {
+	pats := buildLongPatterns(64, 100)
+	tr := buildStopByte16Trie(t, pats)
+	in := concat(pats, 32<<10)
+	if !tr.chainHeavy(in) {
+		t.Fatal("test setup: input must take the chain-heavy dual path")
+	}
+
+	want := naiveMatch(pats, in)
+	ms := tr.Match(in)
+	defer tr.ReleaseMatches(ms)
+	if len(ms) != len(want) {
+		t.Fatalf("match count: got %d, want %d", len(ms), len(want))
+	}
+	for i, m := range ms {
+		if m.Pos() != want[i][0] || m.Pattern() != want[i][1] || len(m.Match()) != int(want[i][2]) {
+			t.Fatalf("match %d: got (pos=%d, pat=%d, len=%d), want (%d, %d, %d)",
+				i, m.Pos(), m.Pattern(), len(m.Match()), want[i][0], want[i][1], want[i][2])
+		}
+	}
+}

--- a/chainheavy_test.go
+++ b/chainheavy_test.go
@@ -129,6 +129,9 @@ func TestDifferentialLongPatternDual(t *testing.T) {
 	if len(in) >= 2*parallelChunk {
 		t.Fatal("test setup: input must stay below the parallel dispatch threshold")
 	}
+	if looksDense(in, tr.rootStopBytes[0]) {
+		t.Fatal("test setup: input must stay below the dense dispatch threshold")
+	}
 	if !tr.chainHeavy(in) {
 		t.Fatal("test setup: input must take the chain-heavy dual path")
 	}

--- a/chainheavy_test.go
+++ b/chainheavy_test.go
@@ -89,6 +89,32 @@ func TestChainHeavySkipFriendlyInput(t *testing.T) {
 	}
 }
 
+// TestChainHeavyMidChainWindows pins the ambiguous-prefix exclusion: the
+// middle and tail sample windows usually start inside an excursion, and
+// the walk (which restarts from the root) must not charge the in-chain
+// bytes before the window's first stop byte as root skips. Kilobyte-scale
+// patterns make that mis-charge fatal - one unaligned window start would
+// spend the whole skip budget - so the verdict must hold at every
+// sampling phase.
+func TestChainHeavyMidChainWindows(t *testing.T) {
+	for _, plen := range []int{256, 512, 1024} {
+		npat := min(30, ((1<<15)-64)/plen)
+		pats := buildLongPatterns(plen, npat)
+		tr := buildStopByte16Trie(t, pats)
+		full := concat(pats, 66000+plen)
+		for ph := 0; ph < 64; ph++ {
+			in := full[ph*plen/64:]
+			in = in[:66000]
+			if !(len(in) >= dualThreshold && int(tr.maxLen)*4 < len(in)/2) {
+				t.Fatalf("plen=%d: dispatch guard fails, bad test setup", plen)
+			}
+			if !tr.chainHeavy(in) {
+				t.Errorf("plen=%d phase=%d: chainHeavy=false; window phase must not decide the verdict", plen, ph)
+			}
+		}
+	}
+}
+
 // TestDifferentialLongPatternDual cross-checks Match against the naive
 // reference on the chain-heavy input that chainHeavy routes to the
 // dual-cursor scan, so the rescued dispatch path stays correct end to end.

--- a/chainheavy_test.go
+++ b/chainheavy_test.go
@@ -193,9 +193,9 @@ func TestDualWorthwhileSampleFloor(t *testing.T) {
 		t.Error("dualWorthwhile=true below the sampling floor for a sparse input")
 	}
 	// The same shape above the floor is rescued.
-	big := concat(pats, 12<<10)
+	big := concat(pats, 20<<10)
 	if len(big) < dualChainFloor*(int(tr.maxLen)+1024) {
-		t.Fatal("test setup: 12KB input must sit above the sampling floor")
+		t.Fatal("test setup: 20KB input must sit above the sampling floor")
 	}
 	if !tr.dualWorthwhile(big) {
 		t.Error("dualWorthwhile=false above the sampling floor for a long-chain input")
@@ -236,6 +236,48 @@ func TestChainSampleExactStateRecovery(t *testing.T) {
 				t.Errorf("%s phase=%d: dualWorthwhile=false on a fully in-chain input", tc.name, ph)
 			}
 		}
+	}
+}
+
+// TestDualWorthwhileUnrepresentativeWindows pins the per-window voting:
+// a pocket of unrepresentative input must not decide the dispatch for
+// the rest.
+func TestDualWorthwhileUnrepresentativeWindows(t *testing.T) {
+	// A 2KB false-start prefix (would exhaust a shared sampling budget
+	// with dozens of depth-1 excursions) ahead of a long-chain body:
+	// the windows past the prefix must outvote it.
+	pats := buildLongPatterns(64, 100)
+	for i, p := range pats {
+		pats[i] = "qa" + p[2:]
+	}
+	tr := buildStopByte16Trie(t, pats)
+	var in []byte
+	for len(in) < 2048 {
+		in = append(in, 'q')
+		in = append(in, bytesFill(8, 'x')...)
+	}
+	in = in[:2048]
+	in = append(in, concat(pats, 62<<10)...)
+	if !tr.dualWorthwhile(in) {
+		t.Error("dualWorthwhile=false: a noisy 2KB prefix outvoted 62KB of long chains")
+	}
+
+	// Filler pockets planted exactly on looksDense's head/mid/tail
+	// windows, long chains everywhere else: the chain windows sit at
+	// different offsets, so the two signals must not share blind spots.
+	pats2 := buildLongPatterns(32, 200)
+	tr2 := buildStopByte16Trie(t, pats2)
+	n := 12 << 10
+	body := concat(pats2, n)
+	fill := bytesFill(1200, 'x')
+	copy(body[0:], fill)
+	copy(body[n/2-100:], fill)
+	copy(body[n-1200:], fill)
+	if looksDense(body, tr2.rootStopBytes[0]) {
+		t.Fatal("test setup: filler must blind the density windows")
+	}
+	if !tr2.dualWorthwhile(body) {
+		t.Error("dualWorthwhile=false: chain windows share looksDense's blind spots")
 	}
 }
 

--- a/chainheavy_test.go
+++ b/chainheavy_test.go
@@ -1,11 +1,13 @@
 package ahocorasick
 
-// Tests for the chain-occupancy dispatch gate (chainHeavy): the second
-// dual-cursor routing signal for inputs whose stop-byte density is low
-// but whose bytes are almost all serial transition loads (long-pattern
-// excursions). looksDense alone misses that regime; these tests pin the
-// routing on both sides of the occupancy boundary and cross-check the
-// rescued path against the naive reference.
+// Tests for the excursion-shape dispatch gate (dualWorthwhile /
+// chainSample): the routing signal that catches what stop-byte density
+// alone misses. Density measures excursion starts; the dual-cursor win
+// tracks excursion LENGTH (long serial transition chains), so the gate
+// samples mean chain length and overrides the density verdict in the
+// decisive zones (dualChainLongMin / dualChainShortMax) on both sides.
+// These tests pin the routing on both sides of each boundary and
+// cross-check the rescued path against the naive reference.
 
 import (
 	"math/rand"
@@ -33,92 +35,10 @@ func buildLongPatterns(plen, npat int) []string {
 	return pats
 }
 
-// concat repeats patterns round-robin until the result reaches size.
-func concat(patterns []string, size int) []byte {
-	var in []byte
-	for i := 0; len(in) < size; i++ {
-		in = append(in, patterns[i%len(patterns)]...)
-	}
-	return in[:size]
-}
-
-func TestChainHeavyLongPatternInput(t *testing.T) {
-	for _, plen := range []int{32, 64, 100} {
-		pats := buildLongPatterns(plen, 200)
-		tr := buildStopByte16Trie(t, pats)
-		in := concat(pats, 64<<10)
-
-		// The workload this gate exists for: ~1-3% stop-byte density,
-		// ~100% chain occupancy. looksDense must reject it (density is
-		// below dualDenseThreshold) and chainHeavy must rescue it.
-		if looksDense(in, tr.rootStopBytes[0]) {
-			t.Fatalf("plen=%d: looksDense=true; input no longer exercises the low-density regime", plen)
-		}
-		if !tr.chainHeavy(in) {
-			t.Errorf("plen=%d: chainHeavy=false for concatenated long patterns", plen)
-		}
-	}
-}
-
-func TestChainHeavySkipFriendlyInput(t *testing.T) {
-	pats := buildLongPatterns(32, 200)
-	tr := buildStopByte16Trie(t, pats)
-
-	// Filler-separated occurrences: every fourth 32-byte pattern is a
-	// 96-byte 'x' run the root skip leaps over (~25% occupancy), the
-	// regime where the single cursor's inline skip wins.
-	var in []byte
-	for i := 0; len(in) < 64<<10; i++ {
-		in = append(in, pats[i%len(pats)]...)
-		in = append(in, bytesFill(96, 'x')...)
-	}
-	in = in[:64<<10]
-	if tr.chainHeavy(in) {
-		t.Error("chainHeavy=true for skip-friendly filler input")
-	}
-
-	// No stop byte at all: the skip budget must exhaust immediately.
-	if tr.chainHeavy(bytesFill(64<<10, 'x')) {
-		t.Error("chainHeavy=true for input without stop bytes")
-	}
-
-	// At or below 4KB the sample would be a significant fraction of the
-	// scan, so the gate stays closed regardless of content.
-	if tr.chainHeavy(concat(pats, 4096)) {
-		t.Error("chainHeavy=true for 4KB input; small inputs must not pay the sample walk")
-	}
-}
-
-// TestChainHeavyMidChainWindows pins the ambiguous-prefix exclusion: the
-// middle and tail sample windows usually start inside an excursion, and
-// the walk (which restarts from the root) must not charge the in-chain
-// bytes before the window's first stop byte as root skips. Kilobyte-scale
-// patterns make that mis-charge fatal - one unaligned window start would
-// spend the whole skip budget - so the verdict must hold at every
-// sampling phase.
-func TestChainHeavyMidChainWindows(t *testing.T) {
-	for _, plen := range []int{256, 512, 1024} {
-		npat := min(30, ((1<<15)-64)/plen)
-		pats := buildLongPatterns(plen, npat)
-		tr := buildStopByte16Trie(t, pats)
-		full := concat(pats, 66000+plen)
-		for ph := 0; ph < 64; ph++ {
-			in := full[ph*plen/64:]
-			in = in[:66000]
-			if !(len(in) >= dualThreshold && int(tr.maxLen)*4 < len(in)/2) {
-				t.Fatalf("plen=%d: dispatch guard fails, bad test setup", plen)
-			}
-			if !tr.chainHeavy(in) {
-				t.Errorf("plen=%d phase=%d: chainHeavy=false; window phase must not decide the verdict", plen, ph)
-			}
-		}
-	}
-}
-
 // buildInternalStopPatterns returns npat patterns of length plen whose
 // stop byte 'q' appears at offset 0 and again at plen/2, with an all-'z'
 // tail: a mid-window sample usually lands after an internal stop byte,
-// which must not derail the occupancy estimate.
+// which must not derail the excursion measurement.
 func buildInternalStopPatterns(plen, npat int) []string {
 	rng := rand.New(rand.NewSource(7))
 	pats := make([]string, npat)
@@ -140,25 +60,168 @@ func buildInternalStopPatterns(plen, npat int) []string {
 	return pats
 }
 
-// TestChainHeavyExactStateRecovery pins the warm-up replay: the sample
+// concat repeats patterns round-robin until the result reaches size.
+func concat(patterns []string, size int) []byte {
+	var in []byte
+	for i := 0; len(in) < size; i++ {
+		in = append(in, patterns[i%len(patterns)]...)
+	}
+	return in[:size]
+}
+
+// TestDualWorthwhileLongChainInput pins the long-chain override: inputs
+// whose excursions are long serial transition chains must route to the
+// dual scan even though their stop-byte density is far below
+// dualDenseThreshold (1-3% here), and whether or not filler gaps push
+// occupancy down (dual measures ~1.4-2x faster on these shapes even at
+// ~25% occupancy).
+func TestDualWorthwhileLongChainInput(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		plen int
+		fill int
+	}{
+		{"concat-plen32", 32, 0},
+		{"concat-plen64", 64, 0},
+		{"concat-plen100", 100, 0},
+		{"gapped-plen32-fill96", 32, 96},
+		{"gapped-plen100-fill100", 100, 100},
+	} {
+		pats := buildLongPatterns(tc.plen, 200)
+		tr := buildStopByte16Trie(t, pats)
+		var in []byte
+		for i := 0; len(in) < 64<<10; i++ {
+			in = append(in, pats[i%len(pats)]...)
+			in = append(in, bytesFill(tc.fill, 'x')...)
+		}
+		in = in[:64<<10]
+		if looksDense(in, tr.rootStopBytes[0]) {
+			t.Fatalf("%s: looksDense=true; input no longer exercises the low-density regime", tc.name)
+		}
+		if !tr.dualWorthwhile(in) {
+			t.Errorf("%s: dualWorthwhile=false for a long-chain input", tc.name)
+		}
+	}
+}
+
+// TestDualWorthwhileShortChainInput pins the short-chain side: inputs
+// whose excursions die within a few bytes must stay on the single
+// cursor. The false-start shape (stop byte frequent, chains dying at
+// depth ~2) is the critical case: it passes the density gate, so only
+// the sampled chain length keeps it off the dual path (single measures
+// ~1.4x faster there).
+func TestDualWorthwhileShortChainInput(t *testing.T) {
+	// False starts: patterns all continue 'qa...', haystack repeats
+	// 'q' + filler, so every excursion is a depth-1 false start.
+	pats := buildLongPatterns(16, 200)
+	for i, p := range pats {
+		pats[i] = "qa" + p[2:]
+	}
+	tr := buildStopByte16Trie(t, pats)
+	var in []byte
+	for len(in) < 64<<10 {
+		in = append(in, 'q')
+		in = append(in, bytesFill(8, 'x')...)
+	}
+	in = in[:64<<10]
+	if !looksDense(in, tr.rootStopBytes[0]) {
+		t.Fatal("test setup: false-start input must pass the density gate")
+	}
+	if tr.dualWorthwhile(in) {
+		t.Error("dualWorthwhile=true for a dense false-start input; short chains must veto the density verdict")
+	}
+
+	// No stop byte at all: nothing sampled, low density decides.
+	if tr.dualWorthwhile(bytesFill(64<<10, 'x')) {
+		t.Error("dualWorthwhile=true for input without stop bytes")
+	}
+}
+
+// TestDualWorthwhileGrayZoneDefersToDensity pins the gray zone:
+// word-length excursions (~9-13 bytes) sit between the decisive bands,
+// where the winner is workload- and machine-dependent, so the density
+// calibration must decide exactly as it did before the chain sampler
+// existed.
+func TestDualWorthwhileGrayZoneDefersToDensity(t *testing.T) {
+	patterns, err := readPatterns("./test_data/NSF-ordlisten.cleaned.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := NewTrieBuilder().AddStrings(patterns[:10000]).Build()
+	if tr.failTrans16 == nil || len(tr.rootStopBytes) != 1 {
+		t.Fatal("test setup: dictionary trie must take the 16-bit single-stop-byte path")
+	}
+	for _, tc := range []struct {
+		gap  int
+		want bool
+	}{
+		{0, true},   // concatenated words: dense -> dual
+		{16, false}, // wide gaps: sparse -> single
+	} {
+		var in []byte
+		for i := 0; len(in) < 96<<10; i++ {
+			in = append(in, patterns[i%10000]...)
+			in = append(in, bytesFill(tc.gap, 'x')...)
+		}
+		in = in[:96<<10]
+		dense := looksDense(in, tr.rootStopBytes[0])
+		if dense != tc.want {
+			t.Fatalf("test setup: gap=%d want looksDense=%v", tc.gap, tc.want)
+		}
+		if got := tr.dualWorthwhile(in); got != tc.want {
+			t.Errorf("gap=%d: dualWorthwhile=%v, want the density verdict %v (gray zone must defer)", tc.gap, got, tc.want)
+		}
+	}
+}
+
+// TestDualWorthwhileSampleFloor pins the sampling cost floor: below
+// dualChainFloor*(maxLen-1+1024) the warm-up replays cannot pay for
+// themselves, so the gate must fall back to the density verdict without
+// sampling.
+func TestDualWorthwhileSampleFloor(t *testing.T) {
+	pats := buildLongPatterns(600, 50)
+	tr := buildStopByte16Trie(t, pats)
+	// 5KB of concatenated 600-byte patterns: passes the dispatch size
+	// guards (n > 8*maxLen fails -> actually guarded upstream), sits
+	// under the sampling floor, and is sparse, so the verdict must be
+	// the density one (false) with no replay.
+	in := concat(pats, 5<<10)
+	if got, want := len(in) < dualChainFloor*(int(tr.maxLen)+1024), true; got != want {
+		t.Fatal("test setup: input must sit below the sampling floor")
+	}
+	if tr.dualWorthwhile(in) {
+		t.Error("dualWorthwhile=true below the sampling floor for a sparse input")
+	}
+	// The same shape above the floor is rescued.
+	big := concat(pats, 12<<10)
+	if len(big) < dualChainFloor*(int(tr.maxLen)+1024) {
+		t.Fatal("test setup: 12KB input must sit above the sampling floor")
+	}
+	if !tr.dualWorthwhile(big) {
+		t.Error("dualWorthwhile=false above the sampling floor for a long-chain input")
+	}
+}
+
+// TestChainSampleExactStateRecovery pins the warm-up replay: the sample
 // walk must hold the real scan's state at every counted byte, so the
-// verdict cannot be derailed by where a window happens to land. Three
-// window placements that defeated the previous window-local heuristics:
+// verdict cannot be derailed by where a window happens to land. Window
+// placements that defeated earlier window-local heuristics, swept across
+// sampling phases:
 //
 //   - internal stop bytes: a window starting after a pattern's internal
-//     'q' must not re-enter the automaton at the wrong prefix and charge
-//     the rest of the occurrence as skips;
+//     'q' must not re-enter the automaton at the wrong prefix and
+//     misread the rest of the occurrence;
 //   - patterns wider than the 1KB window: a window wholly inside an
-//     excursion has no stop byte at all and must still count as in-chain
-//     evidence;
-//   - both fully in-chain shapes must pass at every sampling phase.
-func TestChainHeavyExactStateRecovery(t *testing.T) {
+//     excursion has no stop byte at all and must still count as one
+//     long excursion rather than no evidence.
+func TestChainSampleExactStateRecovery(t *testing.T) {
 	cases := []struct {
 		name string
 		pats []string
 	}{
 		{"internal-stop-plen1024", buildInternalStopPatterns(1024, 30)},
 		{"wider-than-window-plen2048", buildLongPatterns(2048, 15)},
+		{"mid-chain-plen512", buildLongPatterns(512, 60)},
 	}
 	for _, tc := range cases {
 		tr := buildStopByte16Trie(t, tc.pats)
@@ -169,51 +232,22 @@ func TestChainHeavyExactStateRecovery(t *testing.T) {
 			if !(len(in) >= dualThreshold && int(tr.maxLen)*4 < len(in)/2) {
 				t.Fatalf("%s: dispatch guard fails, bad test setup", tc.name)
 			}
-			if !tr.chainHeavy(in) {
-				t.Errorf("%s phase=%d: chainHeavy=false on a fully in-chain input", tc.name, ph)
+			if !tr.dualWorthwhile(in) {
+				t.Errorf("%s phase=%d: dualWorthwhile=false on a fully in-chain input", tc.name, ph)
 			}
 		}
 	}
 }
 
-// TestChainHeavyLargeMaxLenFillerInput pins the false-positive side of
-// the warm-up replay: with kilobyte-scale maxLen, real root-skip gaps
-// inside the windows must still be charged (the previous
-// ambiguous-prefix exclusion hid up to maxLen-1 leading skip bytes per
-// window and misrouted ~1/3-occupancy inputs to the dual scan on most
-// phases). A phase or two can still land all three windows inside
-// pattern bodies - that is sampling variance, not systematic bias - so
-// the test bounds the accept rate well below the biased behavior.
-func TestChainHeavyLargeMaxLenFillerInput(t *testing.T) {
-	pats := buildLongPatterns(1024, 30)
-	tr := buildStopByte16Trie(t, pats)
-	var sb []byte
-	for i := 0; len(sb) < 132<<10; i++ {
-		sb = append(sb, pats[i%len(pats)]...)
-		sb = append(sb, bytesFill(2048, 'x')...)
-	}
-	trues := 0
-	for ph := 0; ph < 32; ph++ {
-		in := sb[ph*96:]
-		in = in[:128<<10]
-		if tr.chainHeavy(in) {
-			trues++
-		}
-	}
-	if trues > 8 {
-		t.Errorf("chainHeavy accepted %d/32 phases of a ~1/3-occupancy input; want a small minority (sampling variance only)", trues)
-	}
-}
-
 // TestDifferentialLongPatternDual cross-checks Match against the naive
-// reference on the chain-heavy input that chainHeavy routes to the
+// reference on the long-chain input that dualWorthwhile routes to the
 // dual-cursor scan, so the rescued dispatch path stays correct end to end.
 func TestDifferentialLongPatternDual(t *testing.T) {
 	pats := buildLongPatterns(64, 100)
 	tr := buildStopByte16Trie(t, pats)
-	// Sized inside the serial window: big enough for chainHeavy's 4KB
-	// floor, below Match's 2*parallelChunk parallel dispatch, so the
-	// scan is guaranteed to go matchSeq -> chainHeavy -> dual-cursor
+	// Sized inside the serial window: above the chain-sampling floor,
+	// below Match's 2*parallelChunk parallel dispatch, so the scan is
+	// guaranteed to go matchSeq -> dualWorthwhile -> dual-cursor
 	// regardless of GOMAXPROCS.
 	in := concat(pats, 12<<10)
 	if len(in) >= 2*parallelChunk {
@@ -222,8 +256,8 @@ func TestDifferentialLongPatternDual(t *testing.T) {
 	if looksDense(in, tr.rootStopBytes[0]) {
 		t.Fatal("test setup: input must stay below the dense dispatch threshold")
 	}
-	if !tr.chainHeavy(in) {
-		t.Fatal("test setup: input must take the chain-heavy dual path")
+	if !tr.dualWorthwhile(in) {
+		t.Fatal("test setup: input must take the long-chain dual path")
 	}
 
 	want := naiveMatch(pats, in)

--- a/chainheavy_test.go
+++ b/chainheavy_test.go
@@ -115,6 +115,96 @@ func TestChainHeavyMidChainWindows(t *testing.T) {
 	}
 }
 
+// buildInternalStopPatterns returns npat patterns of length plen whose
+// stop byte 'q' appears at offset 0 and again at plen/2, with an all-'z'
+// tail: a mid-window sample usually lands after an internal stop byte,
+// which must not derail the occupancy estimate.
+func buildInternalStopPatterns(plen, npat int) []string {
+	rng := rand.New(rand.NewSource(7))
+	pats := make([]string, npat)
+	for i := range pats {
+		b := make([]byte, plen)
+		b[0] = 'q'
+		for j := 1; j < plen/2; j++ {
+			b[j] = byte('a' + rng.Intn(16))
+			if b[j] == 'q' {
+				b[j] = 'r'
+			}
+		}
+		b[plen/2] = 'q'
+		for j := plen/2 + 1; j < plen; j++ {
+			b[j] = 'z'
+		}
+		pats[i] = string(b)
+	}
+	return pats
+}
+
+// TestChainHeavyExactStateRecovery pins the warm-up replay: the sample
+// walk must hold the real scan's state at every counted byte, so the
+// verdict cannot be derailed by where a window happens to land. Three
+// window placements that defeated the previous window-local heuristics:
+//
+//   - internal stop bytes: a window starting after a pattern's internal
+//     'q' must not re-enter the automaton at the wrong prefix and charge
+//     the rest of the occurrence as skips;
+//   - patterns wider than the 1KB window: a window wholly inside an
+//     excursion has no stop byte at all and must still count as in-chain
+//     evidence;
+//   - both fully in-chain shapes must pass at every sampling phase.
+func TestChainHeavyExactStateRecovery(t *testing.T) {
+	cases := []struct {
+		name string
+		pats []string
+	}{
+		{"internal-stop-plen1024", buildInternalStopPatterns(1024, 30)},
+		{"wider-than-window-plen2048", buildLongPatterns(2048, 15)},
+	}
+	for _, tc := range cases {
+		tr := buildStopByte16Trie(t, tc.pats)
+		full := concat(tc.pats, 68000)
+		for ph := 0; ph < 32; ph++ {
+			in := full[ph*63:]
+			in = in[:64000]
+			if !(len(in) >= dualThreshold && int(tr.maxLen)*4 < len(in)/2) {
+				t.Fatalf("%s: dispatch guard fails, bad test setup", tc.name)
+			}
+			if !tr.chainHeavy(in) {
+				t.Errorf("%s phase=%d: chainHeavy=false on a fully in-chain input", tc.name, ph)
+			}
+		}
+	}
+}
+
+// TestChainHeavyLargeMaxLenFillerInput pins the false-positive side of
+// the warm-up replay: with kilobyte-scale maxLen, real root-skip gaps
+// inside the windows must still be charged (the previous
+// ambiguous-prefix exclusion hid up to maxLen-1 leading skip bytes per
+// window and misrouted ~1/3-occupancy inputs to the dual scan on most
+// phases). A phase or two can still land all three windows inside
+// pattern bodies - that is sampling variance, not systematic bias - so
+// the test bounds the accept rate well below the biased behavior.
+func TestChainHeavyLargeMaxLenFillerInput(t *testing.T) {
+	pats := buildLongPatterns(1024, 30)
+	tr := buildStopByte16Trie(t, pats)
+	var sb []byte
+	for i := 0; len(sb) < 132<<10; i++ {
+		sb = append(sb, pats[i%len(pats)]...)
+		sb = append(sb, bytesFill(2048, 'x')...)
+	}
+	trues := 0
+	for ph := 0; ph < 32; ph++ {
+		in := sb[ph*96:]
+		in = in[:128<<10]
+		if tr.chainHeavy(in) {
+			trues++
+		}
+	}
+	if trues > 8 {
+		t.Errorf("chainHeavy accepted %d/32 phases of a ~1/3-occupancy input; want a small minority (sampling variance only)", trues)
+	}
+}
+
 // TestDifferentialLongPatternDual cross-checks Match against the naive
 // reference on the chain-heavy input that chainHeavy routes to the
 // dual-cursor scan, so the rescued dispatch path stays correct end to end.

--- a/trie.go
+++ b/trie.go
@@ -463,9 +463,9 @@ const dualThreshold = 1024
 const dualDenseThreshold = 410
 
 // sampleWindows returns the three 1KB windows (head, middle, tail) that
-// the dispatch heuristics sample. looksDense and chainHeavy were
-// calibrated on the same windows, so both must sample identically; the
-// caller guarantees len(input) > 4096.
+// looksDense samples; the caller guarantees len(input) > 4096.
+// chainHeavy samples the same regions but shifts its head window to
+// start after the automaton warm-up prefix (see chainHeavy).
 func sampleWindows(input []byte) [3][]byte {
 	mid := len(input) / 2
 	return [3][]byte{input[:1024], input[mid : mid+1024], input[len(input)-1024:]}
@@ -494,96 +494,82 @@ func looksDense(input []byte, c byte) bool {
 }
 
 // dualChainSkipMax is the maximum number of root-skippable bytes, out of
-// the up-to-3KB chainHeavy sample, for the input to still count as
-// chain-heavy (in-chain occupancy >= 7/8 of the counted bytes).
-// Calibrated on the same workloads as dualDenseThreshold plus
-// concatenated long patterns: word-plus-filler mixtures that favor the
-// single cursor sample at <= 0.79 occupancy, concatenated dictionary
-// words at >= 0.91, and concatenated 32-1024 byte patterns (~0.1-3%
-// stop-byte density, dual wins ~1.8-2x, measured on Neoverse) at
-// >= 0.98. Natural text samples at ~0.10 and exhausts the budget within
-// the first window.
+// the 3KB chainHeavy sample, for the input to still count as chain-heavy
+// (in-chain occupancy >= 7/8 of the sampled bytes). Calibrated on the
+// same workloads as dualDenseThreshold plus concatenated long patterns:
+// word-plus-filler mixtures that favor the single cursor sample at
+// <= 0.79 occupancy, concatenated dictionary words at >= 0.91, and
+// concatenated 32-2048 byte patterns (~0.05-3% stop-byte density, dual
+// wins ~1.8-2x, measured on Neoverse) at >= 0.98. Natural text samples
+// at ~0.10 and exhausts the budget within the first window.
 const dualChainSkipMax = 384
-
-// dualChainMinSample is the minimum number of counted (non-excluded)
-// sample bytes for a chain-heavy verdict. Windows may exclude up to
-// maxLen-1 ambiguous leading bytes each; if nearly everything is
-// excluded there is no evidence either way, and the dispatch keeps the
-// single-cursor default.
-const dualChainMinSample = 256
 
 // chainHeavy samples three 1KB windows of input (head, middle, tail) by
 // walking the automaton the same way the scan loop does, and reports
-// whether root self-loop skips are at most 1/8 of the counted sample
-// bytes. It exits early once skips exceed dualChainSkipMax (the ratio
-// can then no longer pass), so skip-friendly inputs (the ones that
-// should stay on the single-cursor path) pay a few IndexByte hops; the
-// full 3KB transition walk is only paid on chain-heavy inputs, where
-// routing to the dual scan recovers orders of magnitude more than the
-// sample costs. Inputs of <= 4KB skip the check: at that size a 3KB
-// walk cancels the dual win.
+// whether root self-loop skips are at most dualChainSkipMax (1/8) of the
+// 3KB sample. It exits early once the skip budget is spent, so
+// skip-friendly inputs (the ones that should stay on the single-cursor
+// path) pay a few IndexByte hops; the full transition walk is only paid
+// on chain-heavy inputs, where routing to the dual scan recovers orders
+// of magnitude more than the sample costs.
+//
+// A window usually starts mid-excursion, where the real scan's state is
+// unknown, so each walk warms up from maxLen-1 bytes before its window:
+// the automaton state at any position is the longest pattern prefix
+// suffixing the input there, at most maxLen bytes, so a walk from root
+// through the warm-up reaches the window's first byte in the exact state
+// the real scan holds there (the same replay matchParallel relies on for
+// its lane starts). Warm-up bytes shift state but are not counted;
+// skipped bytes are counted at their positions inside the window, so the
+// verdict reflects true per-byte occupancy of the sampled kilobytes with
+// no ambiguity exclusions. The head window starts at maxLen-1 for a full
+// warm-up (n > 4096 > 8*maxLen by the dispatch guard keeps that inside
+// the first half; its own pre-window bytes are the scan's one-off
+// startup transient and intentionally not sampled).
+//
+// Inputs of <= 4096 bytes skip the check: at that size the sample is
+// most of the input, and walking it cancels the dual win.
 func (tr *Trie) chainHeavy(input []byte) bool {
 	n := len(input)
 	if n <= 4096 {
 		return false
 	}
-	skips, counted := 0, 0
-	for _, w := range sampleWindows(input) {
+	warm := int(tr.maxLen) - 1
+	mid := n / 2
+	budget := dualChainSkipMax
+	for _, start := range [3]int{warm, mid, n - 1024} {
 		var ok bool
-		skips, counted, ok = tr.chainWalk(w, skips, counted)
+		budget, ok = tr.chainWalk(input[max(start-warm, 0):min(start+1024, n)], warm, budget)
 		if !ok {
 			return false
 		}
 	}
-	return counted >= dualChainMinSample && skips*8 <= counted
+	return true
 }
 
-// chainWalk walks one sample window, accumulating root-skippable bytes
-// into skips and evidence bytes (skips plus transition steps) into
-// counted. It returns false as soon as skips exceeds dualChainSkipMax.
-//
-// A window may start mid-excursion, and the walk cannot know the real
-// scan's state there, so the leading bytes are handled specially: any
-// non-root state's string starts with the stop byte, so a position whose
-// trailing maxLen bytes contain no stop byte is provably at root in the
-// real scan. Bytes before the window's first stop byte are therefore
-// ambiguous for the first maxLen-1 positions - excluded from both
-// counts - and provable skips after that. Without the exclusion, a
-// window landing inside a long pattern would charge the in-chain
-// remainder of that occurrence as skips and veto the exact inputs this
-// gate exists to rescue (kilobyte-scale patterns sampled at unaligned
-// offsets). The head window gets the same treatment: its pre-stop-byte
-// prefix is a real skip for the scan, but it is a one-off transient of
-// at most maxLen-1 bytes (< input/8 by the dispatch guard), and
-// charging it would let sample phase, not steady-state behavior, decide
-// the verdict.
-func (tr *Trie) chainWalk(w []byte, skips, counted int) (int, int, bool) {
+// chainWalk walks one sample window preceded by its warm-up prefix of
+// length warm (clamped by the caller at input start), decrementing
+// budget for every root-skippable byte at or beyond the window start.
+// It returns the remaining budget and false as soon as the budget goes
+// negative. Warm-up bytes drive the automaton but are never charged.
+func (tr *Trie) chainWalk(w []byte, warm int, budget int) (int, bool) {
+	if warm >= len(w) {
+		return budget, true
+	}
 	c := tr.rootStopBytes[0]
-	j := bytes.IndexByte(w, c)
-	if j < 0 {
-		j = len(w)
-	}
-	if ambiguous := int(tr.maxLen) - 1; j > ambiguous {
-		skips += j - ambiguous
-		counted += j - ambiguous
-		if skips > dualChainSkipMax {
-			return 0, 0, false
-		}
-	}
-	if j == len(w) {
-		return skips, counted, true
-	}
-	counted += len(w) - j
 	s := rootState
-	for i := j; i < len(w); i++ {
+	for i := 0; i < len(w); i++ {
 		if s == rootState && w[i] != c {
 			k := bytes.IndexByte(w[i:], c)
 			if k < 0 {
 				k = len(w) - i
 			}
-			skips += k
-			if skips > dualChainSkipMax {
-				return 0, 0, false
+			// Only the skipped bytes inside the window proper count.
+			if end := i + k; end > warm {
+				budget -= end - max(i, warm)
+				if budget < 0 {
+					return 0, false
+				}
 			}
 			i += k
 			if i >= len(w) {
@@ -593,7 +579,7 @@ func (tr *Trie) chainWalk(w []byte, skips, counted int) (int, int, bool) {
 		v := tr.failTrans16[int(s)<<8+int(w[i])]
 		s = uint32(v) &^ (1 << 15)
 	}
-	return skips, counted, true
+	return budget, true
 }
 
 // matchSeq scans input sequentially into buf.

--- a/trie.go
+++ b/trie.go
@@ -485,59 +485,99 @@ func looksDense(input []byte, c byte) bool {
 }
 
 // dualChainSkipMax is the maximum number of root-skippable bytes, out of
-// the 3KB chainHeavy samples, for the input to still count as
-// chain-heavy (in-chain occupancy >= 7/8). Calibrated on the same
-// workloads as dualDenseThreshold plus concatenated long patterns:
-// word-plus-filler mixtures that favor the single cursor sample at
-// <= 0.79 occupancy, concatenated dictionary words at >= 0.91, and
-// concatenated 32-100 byte patterns (~1-3% stop-byte density, dual wins
-// ~1.8-2x, measured on Neoverse) at >= 0.98. Natural text samples at
-// ~0.10 and exhausts the budget within the first window.
+// the up-to-3KB chainHeavy sample, for the input to still count as
+// chain-heavy (in-chain occupancy >= 7/8 of the counted bytes).
+// Calibrated on the same workloads as dualDenseThreshold plus
+// concatenated long patterns: word-plus-filler mixtures that favor the
+// single cursor sample at <= 0.79 occupancy, concatenated dictionary
+// words at >= 0.91, and concatenated 32-1024 byte patterns (~0.1-3%
+// stop-byte density, dual wins ~1.8-2x, measured on Neoverse) at
+// >= 0.98. Natural text samples at ~0.10 and exhausts the budget within
+// the first window.
 const dualChainSkipMax = 384
+
+// dualChainMinSample is the minimum number of counted (non-excluded)
+// sample bytes for a chain-heavy verdict. Windows may exclude up to
+// maxLen-1 ambiguous leading bytes each; if nearly everything is
+// excluded there is no evidence either way, and the dispatch keeps the
+// single-cursor default.
+const dualChainMinSample = 256
 
 // chainHeavy samples three 1KB windows of input (head, middle, tail) by
 // walking the automaton the same way the scan loop does, and reports
-// whether at most dualChainSkipMax of the sampled bytes were root
-// self-loop skips. It exits early once the skip budget is spent, so
-// skip-friendly inputs (the ones that should stay on the single-cursor
-// path) pay a few IndexByte hops; the full 3KB transition walk is only
-// paid on chain-heavy inputs, where routing to the dual scan recovers
-// orders of magnitude more than the sample costs. Inputs of <= 4KB skip
-// the check: at that size a 3KB walk cancels the dual win.
+// whether root self-loop skips are at most 1/8 of the counted sample
+// bytes. It exits early once skips exceed dualChainSkipMax (the ratio
+// can then no longer pass), so skip-friendly inputs (the ones that
+// should stay on the single-cursor path) pay a few IndexByte hops; the
+// full 3KB transition walk is only paid on chain-heavy inputs, where
+// routing to the dual scan recovers orders of magnitude more than the
+// sample costs. Inputs of <= 4KB skip the check: at that size a 3KB
+// walk cancels the dual win.
 func (tr *Trie) chainHeavy(input []byte) bool {
 	n := len(input)
 	if n <= 4096 {
 		return false
 	}
 	mid := n / 2
-	budget := dualChainSkipMax
+	skips, counted := 0, 0
 	for _, w := range [3][]byte{input[:1024], input[mid : mid+1024], input[n-1024:]} {
 		var ok bool
-		budget, ok = tr.chainWalk(w, budget)
+		skips, counted, ok = tr.chainWalk(w, skips, counted)
 		if !ok {
 			return false
 		}
 	}
-	return true
+	return counted >= dualChainMinSample && skips*8 <= counted
 }
 
-// chainWalk walks one sample window, decrementing budget for every byte
-// covered by a root self-loop skip. It returns the remaining budget and
-// false as soon as the budget goes negative.
-func (tr *Trie) chainWalk(w []byte, budget int) (int, bool) {
+// chainWalk walks one sample window, accumulating root-skippable bytes
+// into skips and evidence bytes (skips plus transition steps) into
+// counted. It returns false as soon as skips exceeds dualChainSkipMax.
+//
+// A window may start mid-excursion, and the walk cannot know the real
+// scan's state there, so the leading bytes are handled specially: any
+// non-root state's string starts with the stop byte, so a position whose
+// trailing maxLen bytes contain no stop byte is provably at root in the
+// real scan. Bytes before the window's first stop byte are therefore
+// ambiguous for the first maxLen-1 positions - excluded from both
+// counts - and provable skips after that. Without the exclusion, a
+// window landing inside a long pattern would charge the in-chain
+// remainder of that occurrence as skips and veto the exact inputs this
+// gate exists to rescue (kilobyte-scale patterns sampled at unaligned
+// offsets). The head window gets the same treatment: its pre-stop-byte
+// prefix is a real skip for the scan, but it is a one-off transient of
+// at most maxLen-1 bytes (< input/8 by the dispatch guard), and
+// charging it would let sample phase, not steady-state behavior, decide
+// the verdict.
+func (tr *Trie) chainWalk(w []byte, skips, counted int) (int, int, bool) {
 	c := tr.rootStopBytes[0]
+	j := bytes.IndexByte(w, c)
+	if j < 0 {
+		j = len(w)
+	}
+	if ambiguous := int(tr.maxLen) - 1; j > ambiguous {
+		skips += j - ambiguous
+		counted += j - ambiguous
+		if skips > dualChainSkipMax {
+			return 0, 0, false
+		}
+	}
+	if j == len(w) {
+		return skips, counted, true
+	}
+	counted += len(w) - j
 	s := uint32(rootState)
-	for i := 0; i < len(w); i++ {
+	for i := j; i < len(w); i++ {
 		if s == rootState && w[i] != c {
-			j := bytes.IndexByte(w[i:], c)
-			if j < 0 {
-				j = len(w) - i
+			k := bytes.IndexByte(w[i:], c)
+			if k < 0 {
+				k = len(w) - i
 			}
-			budget -= j
-			if budget < 0 {
-				return 0, false
+			skips += k
+			if skips > dualChainSkipMax {
+				return 0, 0, false
 			}
-			i += j
+			i += k
 			if i >= len(w) {
 				break
 			}
@@ -545,7 +585,7 @@ func (tr *Trie) chainWalk(w []byte, budget int) (int, bool) {
 		v := tr.failTrans16[int(s)<<8+int(w[i])]
 		s = uint32(v) &^ (1 << 15)
 	}
-	return budget, true
+	return skips, counted, true
 }
 
 // matchSeq scans input sequentially into buf.

--- a/trie.go
+++ b/trie.go
@@ -466,6 +466,12 @@ const dualDenseThreshold = 410
 // tail) and reports whether the stop-byte density is high enough for the
 // dual-cursor scan to pay. Costs three vectorized bytes.Count calls,
 // noise against a scan that touches every byte.
+//
+// Stop-byte density is a proxy for excursion *starts*, not for bytes
+// spent inside excursions, so it under-reports the in-chain share when
+// patterns are long: input following 100-byte patterns sits near 1%
+// density while nearly every byte is a serial transition load. chainHeavy
+// is the second gate that catches that regime.
 func looksDense(input []byte, c byte) bool {
 	n := len(input)
 	if n <= 4096 {
@@ -478,15 +484,80 @@ func looksDense(input []byte, c byte) bool {
 	return k*4 >= dualDenseThreshold*3
 }
 
+// dualChainSkipMax is the maximum number of root-skippable bytes, out of
+// the 3KB chainHeavy samples, for the input to still count as
+// chain-heavy (in-chain occupancy >= 7/8). Calibrated on the same
+// workloads as dualDenseThreshold plus concatenated long patterns:
+// word-plus-filler mixtures that favor the single cursor sample at
+// <= 0.79 occupancy, concatenated dictionary words at >= 0.91, and
+// concatenated 32-100 byte patterns (~1-3% stop-byte density, dual wins
+// ~1.8-2x, measured on Neoverse) at >= 0.98. Natural text samples at
+// ~0.10 and exhausts the budget within the first window.
+const dualChainSkipMax = 384
+
+// chainHeavy samples three 1KB windows of input (head, middle, tail) by
+// walking the automaton the same way the scan loop does, and reports
+// whether at most dualChainSkipMax of the sampled bytes were root
+// self-loop skips. It exits early once the skip budget is spent, so
+// skip-friendly inputs (the ones that should stay on the single-cursor
+// path) pay a few IndexByte hops; the full 3KB transition walk is only
+// paid on chain-heavy inputs, where routing to the dual scan recovers
+// orders of magnitude more than the sample costs. Inputs of <= 4KB skip
+// the check: at that size a 3KB walk cancels the dual win.
+func (tr *Trie) chainHeavy(input []byte) bool {
+	n := len(input)
+	if n <= 4096 {
+		return false
+	}
+	mid := n / 2
+	budget := dualChainSkipMax
+	for _, w := range [3][]byte{input[:1024], input[mid : mid+1024], input[n-1024:]} {
+		var ok bool
+		budget, ok = tr.chainWalk(w, budget)
+		if !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// chainWalk walks one sample window, decrementing budget for every byte
+// covered by a root self-loop skip. It returns the remaining budget and
+// false as soon as the budget goes negative.
+func (tr *Trie) chainWalk(w []byte, budget int) (int, bool) {
+	c := tr.rootStopBytes[0]
+	s := uint32(rootState)
+	for i := 0; i < len(w); i++ {
+		if s == rootState && w[i] != c {
+			j := bytes.IndexByte(w[i:], c)
+			if j < 0 {
+				j = len(w) - i
+			}
+			budget -= j
+			if budget < 0 {
+				return 0, false
+			}
+			i += j
+			if i >= len(w) {
+				break
+			}
+		}
+		v := tr.failTrans16[int(s)<<8+int(w[i])]
+		s = uint32(v) &^ (1 << 15)
+	}
+	return budget, true
+}
+
 // matchSeq scans input sequentially into buf.
 func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 	if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 {
 		// Dual-scan only when the maxLen-1 bytes lane B re-scans are a
-		// small fraction of a half, and the input is dense enough in
-		// stop bytes that overlapping two transition chains beats the
-		// single-cursor loop's inline root skip.
+		// small fraction of a half, and the input either is dense enough
+		// in stop bytes or keeps the automaton in-chain nearly everywhere,
+		// so overlapping two transition chains beats the single-cursor
+		// loop's inline root skip.
 		if len(input) >= dualThreshold && int(tr.maxLen)*4 < len(input)/2 &&
-			looksDense(input, tr.rootStopBytes[0]) {
+			(looksDense(input, tr.rootStopBytes[0]) || tr.chainHeavy(input)) {
 			tr.matchDualStopByte16(input, buf)
 			return
 		}

--- a/trie.go
+++ b/trie.go
@@ -518,63 +518,69 @@ const (
 	// favor of the single cursor; the shortest dense dual winners are
 	// word-like at >= 11).
 	dualChainShortMax = 6
-	// Sampling stops once this many chain bytes or excursions have been
-	// observed: the mean is stable by then, and the caps bound the
-	// sample cost on chain-dense inputs to ~512 table loads regardless
-	// of input size.
-	dualSampleMaxSteps      = 512
-	dualSampleMaxExcursions = 48
-	// Minimum evidence for a decisive verdict. The long verdict claims
+	// Per-window sampling caps: each window stops once it has observed
+	// this many chain bytes or excursions. The per-window mean is stable
+	// by then, and the caps bound the sample cost on chain-dense inputs
+	// to ~4*256 table loads regardless of input size. The caps are per
+	// window - never shared across windows - so an unrepresentative
+	// region (a false-start prefix, a filler pocket) exhausts only its
+	// own window's budget and cannot starve the others of evidence.
+	dualSampleMaxSteps      = 256
+	dualSampleMaxExcursions = 24
+	// Minimum per-window evidence to cast a vote. The long vote claims
 	// chains are long and is witnessed by chain-byte mass; the short
-	// verdict claims chains die young and needs enough distinct
-	// excursions to say so. Below these the windows mostly missed the
-	// input's excursions and the gray-zone density verdict stands.
-	dualSampleMinChainBytes = 128
-	dualSampleMinExcursions = 16
+	// vote claims chains die young and needs enough distinct excursions
+	// to say so. A window below both thresholds saw too little to have
+	// an opinion and abstains.
+	dualSampleMinChainBytes = 64
+	dualSampleMinExcursions = 8
 )
 
 // dualChainFloor scales the minimum input size for chain sampling: below
-// dualChainFloor*(maxLen+1024) the up-to-three warm-up replays cannot
-// pay for themselves even when the verdict is dual (the dual scan saves
-// ~45-50% of a single scan, so the sample must stay well under half the
-// input), and the gate falls back to the density verdict alone. A
-// chain-heavy input below the floor keeps the single cursor: slower than
-// the dual scan, but cheaper than buying the dual win at full sample
-// price on a small input.
-const dualChainFloor = 7
+// dualChainFloor*(maxLen+1024) the four warm-up replays cannot pay for
+// themselves even when the verdict is dual (the dual scan saves ~45-50%
+// of a single scan, so the sample must stay well under half the input),
+// and the gate falls back to the density verdict alone. A chain-heavy
+// input below the floor keeps the single cursor: slower than the dual
+// scan, but cheaper than buying the dual win at full sample price on a
+// small input. The floor also keeps small inputs - where dispatch
+// overhead is most visible against the scan - off the sampler entirely.
+const dualChainFloor = 10
 
 // dualWorthwhile decides matchSeq's dual-vs-single routing for inputs
 // that passed the size guards. The density check is the cheap first
-// signal; when the input is big enough to sample, the measured mean
-// excursion length overrides it in the two decisive zones and defers to
-// it in the gray zone between.
+// signal; when the input is big enough to sample, each sampled window
+// casts a long/short/abstain vote on its local mean excursion length,
+// and a majority of decided windows overrides the density verdict in
+// either direction. Ties and all-abstain samples defer to density, so
+// windows that land in unrepresentative pockets (filler runs, a noisy
+// prefix) are outvoted by the windows that saw the input's real shape
+// instead of deciding for them.
 func (tr *Trie) dualWorthwhile(input []byte) bool {
 	dense := looksDense(input, tr.rootStopBytes[0])
 	if len(input) < dualChainFloor*(int(tr.maxLen)+1024) {
 		return dense
 	}
-	chainBytes, excursions := tr.chainSample(input)
-	if excursions == 0 {
-		// No chain entered the sample windows; nothing measured (the
-		// input is either skip-dominated or the windows missed its
-		// excursions), so the density verdict stands.
-		return dense
-	}
-	if chainBytes >= dualSampleMinChainBytes && chainBytes >= dualChainLongMin*excursions {
+	long, short := tr.chainSample(input)
+	if long > short {
 		return true
 	}
-	if excursions >= dualSampleMinExcursions && chainBytes < dualChainShortMax*excursions {
+	if short > long {
 		return false
 	}
 	return dense
 }
 
-// chainSample walks up to three 1KB windows of input (head, middle,
-// tail) the same way the scan loop does and returns the number of
-// in-chain (table-step) bytes and the number of excursions (maximal
-// in-chain runs) they contain, stopping early at the dualSampleMax caps.
-// Skip-dominated windows cost a few IndexByte hops; chain-dense windows
-// cost table loads, bounded by the caps.
+// chainSample walks four 1KB windows of input the same way the scan
+// loop does and returns how many voted long (local mean excursion
+// length >= dualChainLongMin) and how many voted short (mean <
+// dualChainShortMax); windows with too little evidence abstain. The
+// windows sit at the 1/8, 3/8, 5/8 and 7/8 points - offset from the
+// head/mid/tail windows looksDense counts - so the two signals do not
+// share blind spots: periodic filler that hides the stop bytes from one
+// set of windows still crosses the other. Skip-dominated windows cost a
+// few IndexByte hops; chain-dense windows cost table loads, bounded by
+// the per-window caps.
 //
 // A window usually starts mid-excursion, where the real scan's state is
 // unknown, so each walk warms up from maxLen bytes before its window:
@@ -582,35 +588,30 @@ func (tr *Trie) dualWorthwhile(input []byte) bool {
 // suffixing the input there, at most maxLen bytes long, so a walk from
 // root through the warm-up reaches the window's first byte in the exact
 // state the real scan holds there (the replay matchParallel relies on
-// for its lane starts). Warm-up bytes shift state but are not counted;
-// the head window starts at maxLen for a full warm-up (the
-// dualChainFloor gate keeps that inside the first half; its own
-// pre-window bytes are the scan's one-off startup transient and
-// intentionally not sampled).
-func (tr *Trie) chainSample(input []byte) (chainBytes, excursions int) {
+// for its lane starts). Warm-up bytes shift state but are not counted.
+func (tr *Trie) chainSample(input []byte) (long, short int) {
 	n := len(input)
 	warm := int(tr.maxLen)
-	mid := n / 2
-	for _, start := range [3]int{warm, mid, n - 1024} {
-		chainBytes, excursions = tr.chainWalk(
-			input[max(start-warm, 0):min(start+1024, n)], warm, chainBytes, excursions)
-		if chainBytes >= dualSampleMaxSteps || excursions >= dualSampleMaxExcursions {
-			return
+	for _, num := range [4]int{1, 3, 5, 7} {
+		start := max(num*(n/8)-512, warm)
+		chainBytes, excursions := tr.chainWalk(input[start-warm:min(start+1024, n)], warm)
+		switch {
+		case chainBytes >= dualSampleMinChainBytes && chainBytes >= dualChainLongMin*excursions:
+			long++
+		case excursions >= dualSampleMinExcursions && chainBytes < dualChainShortMax*excursions:
+			short++
 		}
 	}
 	return
 }
 
 // chainWalk walks one sample window preceded by its warm-up prefix of
-// length warm (clamped by the caller at input start), accumulating
-// in-chain bytes and excursions observed at or beyond the window start.
-// An excursion already in progress at the warm-up boundary counts once,
-// so a window wholly inside one long excursion still yields evidence.
-// The walk returns early once either dualSampleMax cap is reached.
-func (tr *Trie) chainWalk(w []byte, warm, chainBytes, excursions int) (int, int) {
-	if warm >= len(w) {
-		return chainBytes, excursions
-	}
+// length warm, returning the in-chain bytes and excursions (maximal
+// in-chain runs) observed at or beyond the window start. An excursion
+// already in progress at the warm-up boundary counts once, so a window
+// wholly inside one long excursion still yields evidence. The walk
+// returns early once either per-window cap is reached.
+func (tr *Trie) chainWalk(w []byte, warm int) (chainBytes, excursions int) {
 	c := tr.rootStopBytes[0]
 	s := rootState
 	// runCounted marks the current excursion as already tallied; it
@@ -620,7 +621,7 @@ func (tr *Trie) chainWalk(w []byte, warm, chainBytes, excursions int) (int, int)
 		if s == rootState && w[i] != c {
 			k := bytes.IndexByte(w[i:], c)
 			if k < 0 {
-				return chainBytes, excursions
+				return
 			}
 			i += k
 		}
@@ -633,14 +634,14 @@ func (tr *Trie) chainWalk(w []byte, warm, chainBytes, excursions int) (int, int)
 				runCounted = true
 			}
 			if chainBytes >= dualSampleMaxSteps || excursions >= dualSampleMaxExcursions {
-				return chainBytes, excursions
+				return
 			}
 		}
 		if s == rootState {
 			runCounted = false
 		}
 	}
-	return chainBytes, excursions
+	return
 }
 
 // matchSeq scans input sequentially into buf.

--- a/trie.go
+++ b/trie.go
@@ -493,105 +493,166 @@ func looksDense(input []byte, c byte) bool {
 	return k*4 >= dualDenseThreshold*3
 }
 
-// dualChainSkipMax is the maximum number of root-skippable bytes, out of
-// the 3KB chainHeavy sample, for the input to still count as chain-heavy
-// (in-chain occupancy >= 7/8 of the sampled bytes). Calibrated on the
-// same workloads as dualDenseThreshold plus concatenated long patterns:
-// word-plus-filler mixtures that favor the single cursor sample at
-// <= 0.79 occupancy, concatenated dictionary words at >= 0.91, and
-// concatenated 32-2048 byte patterns (~0.05-3% stop-byte density, dual
-// wins ~1.8-2x, measured on Neoverse) at >= 0.98. Natural text samples
-// at ~0.10 and exhausts the budget within the first window.
-const dualChainSkipMax = 384
+// The dual-cursor scan pays when the automaton's serial transition
+// chains (excursions) are long: each in-chain step is a dependent load,
+// and a single cursor exposes that full latency chain while two cursors
+// overlap two of them. Short excursions do not need the second cursor -
+// the out-of-order window already overlaps successive short chains
+// across the root skips between them - so the routing signal is the
+// MEAN EXCURSION LENGTH of the input on this automaton, measured by
+// chainSample. Measured on Neoverse at 96KB: word-like inputs (mean
+// chain 9-13 bytes) favor the single cursor by 1.1-1.4x at every
+// density and occupancy tried, while 32+-byte chains favor the dual
+// scan by 1.4-2x even at 24% occupancy. Between those bands the winner
+// is workload- and machine-dependent, so the gray zone defers to the
+// stop-byte-density calibration (dualDenseThreshold, measured on Zen 4).
+const (
+	// dualChainLongMin: mean sampled excursion length at or above which
+	// the dual scan wins regardless of density (shortest measured dual
+	// winner: 33-byte chains at 1.4-1.6x; word-like single winners sit
+	// at <= 13).
+	dualChainLongMin = 24
+	// dualChainShortMax: mean sampled excursion length below which the
+	// single cursor wins regardless of density (false-start inputs -
+	// stop byte frequent but chains dying at depth ~2 - measure 1.4x in
+	// favor of the single cursor; the shortest dense dual winners are
+	// word-like at >= 11).
+	dualChainShortMax = 6
+	// Sampling stops once this many chain bytes or excursions have been
+	// observed: the mean is stable by then, and the caps bound the
+	// sample cost on chain-dense inputs to ~512 table loads regardless
+	// of input size.
+	dualSampleMaxSteps      = 512
+	dualSampleMaxExcursions = 48
+	// Minimum evidence for a decisive verdict. The long verdict claims
+	// chains are long and is witnessed by chain-byte mass; the short
+	// verdict claims chains die young and needs enough distinct
+	// excursions to say so. Below these the windows mostly missed the
+	// input's excursions and the gray-zone density verdict stands.
+	dualSampleMinChainBytes = 128
+	dualSampleMinExcursions = 16
+)
 
-// chainHeavy samples three 1KB windows of input (head, middle, tail) by
-// walking the automaton the same way the scan loop does, and reports
-// whether root self-loop skips are at most dualChainSkipMax (1/8) of the
-// 3KB sample. It exits early once the skip budget is spent, so
-// skip-friendly inputs (the ones that should stay on the single-cursor
-// path) pay a few IndexByte hops; the full transition walk is only paid
-// on chain-heavy inputs, where routing to the dual scan recovers orders
-// of magnitude more than the sample costs.
-//
-// A window usually starts mid-excursion, where the real scan's state is
-// unknown, so each walk warms up from maxLen-1 bytes before its window:
-// the automaton state at any position is the longest pattern prefix
-// suffixing the input there, at most maxLen bytes, so a walk from root
-// through the warm-up reaches the window's first byte in the exact state
-// the real scan holds there (the same replay matchParallel relies on for
-// its lane starts). Warm-up bytes shift state but are not counted;
-// skipped bytes are counted at their positions inside the window, so the
-// verdict reflects true per-byte occupancy of the sampled kilobytes with
-// no ambiguity exclusions. The head window starts at maxLen-1 for a full
-// warm-up (n > 4096 > 8*maxLen by the dispatch guard keeps that inside
-// the first half; its own pre-window bytes are the scan's one-off
-// startup transient and intentionally not sampled).
-//
-// Inputs of <= 4096 bytes skip the check: at that size the sample is
-// most of the input, and walking it cancels the dual win.
-func (tr *Trie) chainHeavy(input []byte) bool {
-	n := len(input)
-	if n <= 4096 {
+// dualChainFloor scales the minimum input size for chain sampling: below
+// dualChainFloor*(maxLen+1024) the up-to-three warm-up replays cannot
+// pay for themselves even when the verdict is dual (the dual scan saves
+// ~45-50% of a single scan, so the sample must stay well under half the
+// input), and the gate falls back to the density verdict alone. A
+// chain-heavy input below the floor keeps the single cursor: slower than
+// the dual scan, but cheaper than buying the dual win at full sample
+// price on a small input.
+const dualChainFloor = 7
+
+// dualWorthwhile decides matchSeq's dual-vs-single routing for inputs
+// that passed the size guards. The density check is the cheap first
+// signal; when the input is big enough to sample, the measured mean
+// excursion length overrides it in the two decisive zones and defers to
+// it in the gray zone between.
+func (tr *Trie) dualWorthwhile(input []byte) bool {
+	dense := looksDense(input, tr.rootStopBytes[0])
+	if len(input) < dualChainFloor*(int(tr.maxLen)+1024) {
+		return dense
+	}
+	chainBytes, excursions := tr.chainSample(input)
+	if excursions == 0 {
+		// No chain entered the sample windows; nothing measured (the
+		// input is either skip-dominated or the windows missed its
+		// excursions), so the density verdict stands.
+		return dense
+	}
+	if chainBytes >= dualSampleMinChainBytes && chainBytes >= dualChainLongMin*excursions {
+		return true
+	}
+	if excursions >= dualSampleMinExcursions && chainBytes < dualChainShortMax*excursions {
 		return false
 	}
-	warm := int(tr.maxLen) - 1
+	return dense
+}
+
+// chainSample walks up to three 1KB windows of input (head, middle,
+// tail) the same way the scan loop does and returns the number of
+// in-chain (table-step) bytes and the number of excursions (maximal
+// in-chain runs) they contain, stopping early at the dualSampleMax caps.
+// Skip-dominated windows cost a few IndexByte hops; chain-dense windows
+// cost table loads, bounded by the caps.
+//
+// A window usually starts mid-excursion, where the real scan's state is
+// unknown, so each walk warms up from maxLen bytes before its window:
+// the automaton state at any position is the longest pattern prefix
+// suffixing the input there, at most maxLen bytes long, so a walk from
+// root through the warm-up reaches the window's first byte in the exact
+// state the real scan holds there (the replay matchParallel relies on
+// for its lane starts). Warm-up bytes shift state but are not counted;
+// the head window starts at maxLen for a full warm-up (the
+// dualChainFloor gate keeps that inside the first half; its own
+// pre-window bytes are the scan's one-off startup transient and
+// intentionally not sampled).
+func (tr *Trie) chainSample(input []byte) (chainBytes, excursions int) {
+	n := len(input)
+	warm := int(tr.maxLen)
 	mid := n / 2
-	budget := dualChainSkipMax
 	for _, start := range [3]int{warm, mid, n - 1024} {
-		var ok bool
-		budget, ok = tr.chainWalk(input[max(start-warm, 0):min(start+1024, n)], warm, budget)
-		if !ok {
-			return false
+		chainBytes, excursions = tr.chainWalk(
+			input[max(start-warm, 0):min(start+1024, n)], warm, chainBytes, excursions)
+		if chainBytes >= dualSampleMaxSteps || excursions >= dualSampleMaxExcursions {
+			return
 		}
 	}
-	return true
+	return
 }
 
 // chainWalk walks one sample window preceded by its warm-up prefix of
-// length warm (clamped by the caller at input start), decrementing
-// budget for every root-skippable byte at or beyond the window start.
-// It returns the remaining budget and false as soon as the budget goes
-// negative. Warm-up bytes drive the automaton but are never charged.
-func (tr *Trie) chainWalk(w []byte, warm int, budget int) (int, bool) {
+// length warm (clamped by the caller at input start), accumulating
+// in-chain bytes and excursions observed at or beyond the window start.
+// An excursion already in progress at the warm-up boundary counts once,
+// so a window wholly inside one long excursion still yields evidence.
+// The walk returns early once either dualSampleMax cap is reached.
+func (tr *Trie) chainWalk(w []byte, warm, chainBytes, excursions int) (int, int) {
 	if warm >= len(w) {
-		return budget, true
+		return chainBytes, excursions
 	}
 	c := tr.rootStopBytes[0]
 	s := rootState
+	// runCounted marks the current excursion as already tallied; it
+	// resets whenever the automaton returns to root.
+	runCounted := false
 	for i := 0; i < len(w); i++ {
 		if s == rootState && w[i] != c {
 			k := bytes.IndexByte(w[i:], c)
 			if k < 0 {
-				k = len(w) - i
-			}
-			// Only the skipped bytes inside the window proper count.
-			if end := i + k; end > warm {
-				budget -= end - max(i, warm)
-				if budget < 0 {
-					return 0, false
-				}
+				return chainBytes, excursions
 			}
 			i += k
-			if i >= len(w) {
-				break
-			}
 		}
 		v := tr.failTrans16[int(s)<<8+int(w[i])]
 		s = uint32(v) &^ (1 << 15)
+		if i >= warm {
+			chainBytes++
+			if !runCounted {
+				excursions++
+				runCounted = true
+			}
+			if chainBytes >= dualSampleMaxSteps || excursions >= dualSampleMaxExcursions {
+				return chainBytes, excursions
+			}
+		}
+		if s == rootState {
+			runCounted = false
+		}
 	}
-	return budget, true
+	return chainBytes, excursions
 }
 
 // matchSeq scans input sequentially into buf.
 func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 	if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 {
 		// Dual-scan only when the maxLen-1 bytes lane B re-scans are a
-		// small fraction of a half, and the input either is dense enough
-		// in stop bytes or keeps the automaton in-chain nearly everywhere,
-		// so overlapping two transition chains beats the single-cursor
-		// loop's inline root skip.
+		// small fraction of a half, and the input's excursion shape
+		// (sampled mean chain length, with stop-byte density as the
+		// fallback signal) says overlapping two transition chains beats
+		// the single-cursor loop's inline root skip.
 		if len(input) >= dualThreshold && int(tr.maxLen)*4 < len(input)/2 &&
-			(looksDense(input, tr.rootStopBytes[0]) || tr.chainHeavy(input)) {
+			tr.dualWorthwhile(input) {
 			tr.matchDualStopByte16(input, buf)
 			return
 		}

--- a/trie.go
+++ b/trie.go
@@ -462,6 +462,15 @@ const dualThreshold = 1024
 // cursor.
 const dualDenseThreshold = 410
 
+// sampleWindows returns the three 1KB windows (head, middle, tail) that
+// the dispatch heuristics sample. looksDense and chainHeavy were
+// calibrated on the same windows, so both must sample identically; the
+// caller guarantees len(input) > 4096.
+func sampleWindows(input []byte) [3][]byte {
+	mid := len(input) / 2
+	return [3][]byte{input[:1024], input[mid : mid+1024], input[len(input)-1024:]}
+}
+
 // looksDense samples up to three 1KB windows of input (head, middle,
 // tail) and reports whether the stop-byte density is high enough for the
 // dual-cursor scan to pay. Costs three vectorized bytes.Count calls,
@@ -477,10 +486,10 @@ func looksDense(input []byte, c byte) bool {
 	if n <= 4096 {
 		return bytes.Count(input, []byte{c})*4096 >= dualDenseThreshold*n
 	}
-	k := bytes.Count(input[:1024], []byte{c})
-	mid := n / 2
-	k += bytes.Count(input[mid:mid+1024], []byte{c})
-	k += bytes.Count(input[n-1024:], []byte{c})
+	k := 0
+	for _, w := range sampleWindows(input) {
+		k += bytes.Count(w, []byte{c})
+	}
 	return k*4 >= dualDenseThreshold*3
 }
 
@@ -518,9 +527,8 @@ func (tr *Trie) chainHeavy(input []byte) bool {
 	if n <= 4096 {
 		return false
 	}
-	mid := n / 2
 	skips, counted := 0, 0
-	for _, w := range [3][]byte{input[:1024], input[mid : mid+1024], input[n-1024:]} {
+	for _, w := range sampleWindows(input) {
 		var ok bool
 		skips, counted, ok = tr.chainWalk(w, skips, counted)
 		if !ok {

--- a/trie.go
+++ b/trie.go
@@ -574,7 +574,7 @@ func (tr *Trie) chainWalk(w []byte, skips, counted int) (int, int, bool) {
 		return skips, counted, true
 	}
 	counted += len(w) - j
-	s := uint32(rootState)
+	s := rootState
 	for i := j; i < len(w); i++ {
 		if s == rootState && w[i] != c {
 			k := bytes.IndexByte(w[i:], c)

--- a/trie.go
+++ b/trie.go
@@ -452,13 +452,41 @@ func (tr *Trie) Match(input []byte) []*Match {
 // dualThreshold is the minimum input size for the dual-cursor scan.
 const dualThreshold = 1024
 
+// dualDenseThreshold is the minimum sampled stop-byte density for the
+// dual-cursor scan, in stop bytes per 4096 input bytes (~10%).
+// Measured on Zen 4: natural text over a single-stop-byte pattern set
+// sits near 3-4% (short excursions, single-cursor inline skip wins by
+// 10-15%), while concatenated dictionary words sit at 11-15% (long
+// dependent-load excursions, dual-cursor wins by 25-45% on small
+// inputs). Word-plus-filler mixtures up to ~9% still favor the single
+// cursor.
+const dualDenseThreshold = 410
+
+// looksDense samples up to three 1KB windows of input (head, middle,
+// tail) and reports whether the stop-byte density is high enough for the
+// dual-cursor scan to pay. Costs three vectorized bytes.Count calls,
+// noise against a scan that touches every byte.
+func looksDense(input []byte, c byte) bool {
+	n := len(input)
+	if n <= 4096 {
+		return bytes.Count(input, []byte{c})*4096 >= dualDenseThreshold*n
+	}
+	k := bytes.Count(input[:1024], []byte{c})
+	mid := n / 2
+	k += bytes.Count(input[mid:mid+1024], []byte{c})
+	k += bytes.Count(input[n-1024:], []byte{c})
+	return k*4 >= dualDenseThreshold*3
+}
+
 // matchSeq scans input sequentially into buf.
 func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 	if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 {
 		// Dual-scan only when the maxLen-1 bytes lane B re-scans are a
-		// small fraction of a half; otherwise the redundant overlap work
-		// outweighs the overlapped load latency.
-		if len(input) >= dualThreshold && int(tr.maxLen)*4 < len(input)/2 {
+		// small fraction of a half, and the input is dense enough in
+		// stop bytes that overlapping two transition chains beats the
+		// single-cursor loop's inline root skip.
+		if len(input) >= dualThreshold && int(tr.maxLen)*4 < len(input)/2 &&
+			looksDense(input, tr.rootStopBytes[0]) {
 			tr.matchDualStopByte16(input, buf)
 			return
 		}

--- a/trie.go
+++ b/trie.go
@@ -464,8 +464,8 @@ const dualDenseThreshold = 410
 
 // sampleWindows returns the three 1KB windows (head, middle, tail) that
 // looksDense samples; the caller guarantees len(input) > 4096.
-// chainHeavy samples the same regions but shifts its head window to
-// start after the automaton warm-up prefix (see chainHeavy).
+// chainSample deliberately uses different offsets (the 1/8, 3/8, 5/8,
+// 7/8 points) so the two dispatch signals do not share blind spots.
 func sampleWindows(input []byte) [3][]byte {
 	mid := len(input) / 2
 	return [3][]byte{input[:1024], input[mid : mid+1024], input[len(input)-1024:]}
@@ -479,8 +479,8 @@ func sampleWindows(input []byte) [3][]byte {
 // Stop-byte density is a proxy for excursion *starts*, not for bytes
 // spent inside excursions, so it under-reports the in-chain share when
 // patterns are long: input following 100-byte patterns sits near 1%
-// density while nearly every byte is a serial transition load. chainHeavy
-// is the second gate that catches that regime.
+// density while nearly every byte is a serial transition load. The
+// chainSample vote in dualWorthwhile catches that regime.
 func looksDense(input []byte, c byte) bool {
 	n := len(input)
 	if n <= 4096 {


### PR DESCRIPTION
> **Stack 4/20** · base: `perf/10-dual-full-gap-skip` · commit: `566ec04`
> Combined perf chain (three research lines consolidated). Review index with per-PR A/B evidence, risk map, and merge order: [PR-CHAIN.md](https://github.com/ahrav/aho-corasick/blob/docs/27-chain-index/PR-CHAIN.md)

The dual-cursor scan overlaps two serial transition-load chains, which
pays only when most bytes ARE transitions. On natural text over a
single-stop-byte pattern set (stop-byte density 3-4%, short root
excursions) it loses 10-15% to the single-cursor loop's inline skip; on
concatenated dictionary words (11-15%) it wins 25-45% on small inputs.

Sample the stop-byte density from three 1KB windows (head/middle/tail,
vectorized bytes.Count, ~tens of ns) and take the dual path only at or
above ~10%. Measured boundary cases: word-plus-filler mixtures at 6-9.6%
favor single-cursor by 6-14%; pure concatenations at 10.9-15% favor dual.

Benchmarks (vs parent, n=6-8): text 100KB -9%, text 4KB -14%; dense
inputs keep the dual win; misclassification only costs speed, never
correctness (both paths emit identical output; covered by the
differential fuzz suite).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved automatic selection of the optimized dual-cursor matching path for inputs with dense stop-byte patterns and chain-heavy automaton behavior.
  * Dual-cursor routing now makes a smarter density/excursion decision, with safe fallback to the prior single-cursor path when appropriate.

* **Reliability**
  * Added extensive deterministic test coverage for long, short, and “gray zone” routing decisions, including sparse and adversarially shaped inputs.
  * Verified optimized matching results match standard matching (counts and exact match details).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->