### PR TITLE
perf: density-aware parallel scan threshold

### DIFF
--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -126,7 +126,7 @@ func fillWithMatches(size int, filler byte, needle string) []byte {
 //   - >1 root stop byte  → matchTable / walkTable
 //   - 1 root stop byte   → matchStopByte16 / walkStopByte
 //   - 1 stop byte, large → matchDualStopByte16 + scanRange16
-//   - input ≥ 16 KiB     → matchParallel (over either family)
+//   - ≥ 32 KiB, table or stop-byte-dense → matchParallel (either family)
 //
 // matchStopByte (the uint32 single-stop-byte loop) needs >2^15 states and
 // is not reachable at fuzzing scale; it is covered only structurally. The
@@ -142,9 +142,14 @@ func FuzzMatch(f *testing.F) {
 	f.Add(encodeSeed("ab", "abc", "abca"), []byte("xxabcaxxabxx"))
 	// 1 stop byte, large — dual-cursor path (≥1024, maxLen*4 < len/2).
 	f.Add(encodeSeed("ab", "abc", "abca"), fillWithMatches(4096, 'x', "abca"))
-	// 1 stop byte, ≥16 KiB — parallel path over dual-cursor chunks.
+	// 1 stop byte, ≥32 KiB but stop-byte-sparse (~1.5%) — pins the
+	// sparse branch of the parallel dispatch keeping the scan
+	// sequential below parallelSparseMin.
 	f.Add(encodeSeed("ab", "abc", "abca"), fillWithMatches(40000, 'x', "abca"))
-	// >1 stop byte, ≥16 KiB — parallel path over table chunks.
+	// 1 stop byte, ≥32 KiB and stop-byte-dense (25%) — parallel path
+	// over dual-cursor chunks.
+	f.Add(encodeSeed("ab", "abc", "abca"), bytes.Repeat([]byte("abcaxxxx"), 5000))
+	// >1 stop byte, ≥32 KiB — parallel path over table chunks.
 	f.Add(encodeSeed("ab", "bc", "ca"), fillWithMatches(40000, 'z', "abca"))
 	// Degenerate inputs.
 	f.Add(encodeSeed("a"), []byte(""))
@@ -153,8 +158,8 @@ func FuzzMatch(f *testing.F) {
 	// match end at *every* position, so a match necessarily lands exactly
 	// on the dual midpoint and every parallel chunk boundary — the
 	// boundaries the drop/rebase and lane-B emit conditions turn on.
-	f.Add(encodeSeed("a", "aa", "aaa"), bytes.Repeat([]byte("a"), 20000))
-	f.Add(encodeSeed("ab", "b", "bab"), bytes.Repeat([]byte("ab"), 10000))
+	f.Add(encodeSeed("a", "aa", "aaa"), bytes.Repeat([]byte("a"), 40000))
+	f.Add(encodeSeed("ab", "b", "bab"), bytes.Repeat([]byte("ab"), 20000))
 
 	f.Fuzz(func(t *testing.T, raw, input []byte) {
 		patterns := patternSetFromRaw(raw)
@@ -163,8 +168,11 @@ func FuzzMatch(f *testing.F) {
 		}
 		// Bound scan cost so no single exec can stall the fuzzer: the
 		// mutator readily grows input to megabytes, and the reference is
-		// O(len·maxLen). 64 KiB still reaches the parallel path (up to 8
-		// workers over 8 KiB chunks) and every dual-cursor boundary.
+		// O(len·maxLen). 64 KiB still reaches the parallel path for
+		// table and stop-byte-dense inputs (up to 8 workers over 8 KiB
+		// chunks) and every dual-cursor boundary; the sparse single-stop
+		// branch past parallelSparseMin is pinned by
+		// TestParallelWorkersPolicy instead.
 		const maxScan = 1 << 16
 		if len(input) > maxScan {
 			input = input[:maxScan]

--- a/trie.go
+++ b/trie.go
@@ -419,12 +419,24 @@ const parallelChunk = 8 << 10
 
 // Match runs the Aho-Corasick string-search algorithm on a byte input.
 func (tr *Trie) Match(input []byte) []*Match {
-	if len(input) >= 2*parallelChunk {
-		// Workers dual-scan their chunks, so more of them mainly adds
-		// wakeup and steal latency; cap at 8 to keep each chunk large
-		// enough to amortize goroutine startup.
-		if p := min(runtime.GOMAXPROCS(0), len(input)/parallelChunk, 8); p > 1 {
-			return tr.matchParallel(input, p)
+	if len(input) >= 32<<10 {
+		// The single-stop-byte automaton scans sparse input at ~2GB/s
+		// serially, so goroutine startup, the redundant overlap
+		// re-scans, and the merge fan-in only pay for themselves near
+		// 128KB; on stop-byte-dense input its serial throughput drops
+		// several-fold and parallelism pays from 32KB, like the slower
+		// table-path automata.
+		pmin := 32 << 10
+		if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 &&
+			!looksDense(input, tr.rootStopBytes[0]) {
+			pmin = 128 << 10
+		}
+		if len(input) >= pmin {
+			// Cap at 8 workers: more of them mainly adds wakeup and
+			// steal latency while the post-scan merge is serial.
+			if p := min(runtime.GOMAXPROCS(0), len(input)/parallelChunk, 8); p > 1 {
+				return tr.matchParallel(input, p)
+			}
 		}
 	}
 

--- a/trie.go
+++ b/trie.go
@@ -417,27 +417,51 @@ func (tr *Trie) walkTable(input []byte, fn WalkFn) {
 // below it, goroutine startup outweighs the scan work.
 const parallelChunk = 8 << 10
 
+// parallelMin is the minimum input size for the parallel scan. The
+// table-path automata scan slowly enough serially that workers pay for
+// themselves from 32KB, as do the single-stop-byte automata on
+// stop-byte-dense input, where excursions drop serial throughput
+// several-fold.
+const parallelMin = 32 << 10
+
+// parallelSparseMin is the minimum input size for the parallel scan on
+// a single-stop-byte automaton over stop-byte-sparse input. Both scan
+// widths of that family (matchStopByte and matchStopByte16) cover
+// sparse input at ~2GB/s serially through the same SWAR/IndexByte root
+// skip, so goroutine startup, the redundant overlap re-scans, and the
+// merge fan-in only pay for themselves near 128KB.
+const parallelSparseMin = 128 << 10
+
+// parallelWorkers reports how many workers Match should hand input to
+// matchParallel with, or 0 for a sequential scan. maxProcs is the
+// caller's runtime.GOMAXPROCS(0), taken as a parameter so tests can pin
+// the policy across CPU counts. The worker gate runs before the density
+// sample so a process that can never parallelize (maxProcs 1) does not
+// pay for sampling it cannot act on.
+func (tr *Trie) parallelWorkers(input []byte, maxProcs int) int {
+	if len(input) < parallelMin {
+		return 0
+	}
+	// Cap at 8 workers: more of them mainly adds wakeup and steal
+	// latency while the post-scan merge is serial.
+	p := min(maxProcs, len(input)/parallelChunk, 8)
+	if p < 2 {
+		return 0
+	}
+	// Between the two thresholds, a single-stop-byte automaton stays
+	// sequential on sparse input; past parallelSparseMin both floors
+	// are cleared, so the sample is skipped outright.
+	if len(input) < parallelSparseMin && len(tr.rootStopBytes) == 1 &&
+		!looksDense(input, tr.rootStopBytes[0]) {
+		return 0
+	}
+	return p
+}
+
 // Match runs the Aho-Corasick string-search algorithm on a byte input.
 func (tr *Trie) Match(input []byte) []*Match {
-	if len(input) >= 32<<10 {
-		// The single-stop-byte automaton scans sparse input at ~2GB/s
-		// serially, so goroutine startup, the redundant overlap
-		// re-scans, and the merge fan-in only pay for themselves near
-		// 128KB; on stop-byte-dense input its serial throughput drops
-		// several-fold and parallelism pays from 32KB, like the slower
-		// table-path automata.
-		pmin := 32 << 10
-		if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 &&
-			!looksDense(input, tr.rootStopBytes[0]) {
-			pmin = 128 << 10
-		}
-		if len(input) >= pmin {
-			// Cap at 8 workers: more of them mainly adds wakeup and
-			// steal latency while the post-scan merge is serial.
-			if p := min(runtime.GOMAXPROCS(0), len(input)/parallelChunk, 8); p > 1 {
-				return tr.matchParallel(input, p)
-			}
-		}
+	if p := tr.parallelWorkers(input, runtime.GOMAXPROCS(0)); p > 0 {
+		return tr.matchParallel(input, p)
 	}
 
 	buf := tr.bufPool.Get().(*matchBuf)

--- a/trie_test.go
+++ b/trie_test.go
@@ -2,6 +2,7 @@ package ahocorasick
 
 import (
 	"bufio"
+	"bytes"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -293,5 +294,86 @@ func TestFailTrans16Gate(t *testing.T) {
 	}
 	if got := multi.MatchString("zebra or amet"); len(got) != 3 {
 		t.Errorf("multiple stop bytes: expected 3 matches, got %d", len(got))
+	}
+}
+
+// buildBigSingleStopTrie builds a single-stop-byte trie with more than
+// 2^15 states, so failTrans16 stays nil and the sequential scan runs the
+// 32-bit matchStopByte loop. Every pattern starts with 'a' and continues
+// over a 32-byte suffix alphabet that excludes 'a', giving
+// 1 + 1 + 32 + 32^2 + 32^3 = 33826 states.
+func buildBigSingleStopTrie(t *testing.T) *Trie {
+	t.Helper()
+	patterns := make([]string, 0, 32*32*32)
+	for i := range 32 {
+		for j := range 32 {
+			for k := range 32 {
+				patterns = append(patterns,
+					string([]byte{'a', byte('A' + i), byte('A' + j), byte('A' + k)}))
+			}
+		}
+	}
+	tr := NewTrieBuilder().AddStrings(patterns).Build()
+	if tr.failTrans16 != nil {
+		t.Fatal("expected >2^15 states to leave failTrans16 nil")
+	}
+	if len(tr.rootStopBytes) != 1 {
+		t.Fatalf("expected a single root stop byte, got %d", len(tr.rootStopBytes))
+	}
+	return tr
+}
+
+// TestParallelWorkersPolicy pins the Match dispatch policy: the worker
+// count and size floors that route input to matchParallel, the sparse
+// single-stop-byte inputs that stay sequential up to parallelSparseMin
+// on both scan widths, and the single-CPU case that must never
+// parallelize regardless of density.
+func TestParallelWorkersPolicy(t *testing.T) {
+	single := NewTrieBuilder().AddStrings([]string{"ab", "abc", "abca"}).Build()
+	if single.failTrans16 == nil || len(single.rootStopBytes) != 1 {
+		t.Fatal("expected a 16-bit single-stop-byte trie")
+	}
+	multi := NewTrieBuilder().AddStrings([]string{"ab", "bc", "ca"}).Build()
+	if len(multi.rootStopBytes) != 0 {
+		t.Fatal("expected a table-path trie (no root stop byte set)")
+	}
+	big := buildBigSingleStopTrie(t)
+
+	// Stop byte 'a' at 1/16 bytes (~6%) sits under the ~10% density
+	// threshold; at 1/8 (~12.5%) it sits over.
+	sparse := func(size int) []byte {
+		return bytes.Repeat([]byte("axxxxxxxxxxxxxxx"), size/16)
+	}
+	dense := func(size int) []byte {
+		return bytes.Repeat([]byte("abcaxxxx"), size/8)
+	}
+
+	cases := []struct {
+		name     string
+		tr       *Trie
+		input    []byte
+		maxProcs int
+		want     int
+	}{
+		{"below parallelMin stays sequential", single, dense(16 << 10), 8, 0},
+		{"single CPU stays sequential", single, dense(40 << 10), 1, 0},
+		{"sparse below parallelSparseMin stays sequential", single, sparse(64 << 10), 8, 0},
+		{"sparse past parallelSparseMin parallelizes", single, sparse(160 << 10), 8, 8},
+		{"dense parallelizes from parallelMin", single, dense(40 << 10), 8, 5},
+		{"table path parallelizes from parallelMin", multi, sparse(40 << 10), 8, 5},
+		{"workers capped at 8", single, dense(160 << 10), 16, 8},
+		{"workers capped by GOMAXPROCS", single, dense(40 << 10), 2, 2},
+		{"32-bit sparse below parallelSparseMin stays sequential", big, sparse(64 << 10), 8, 0},
+		{"32-bit sparse past parallelSparseMin parallelizes", big, sparse(160 << 10), 8, 8},
+		{"32-bit dense parallelizes from parallelMin", big, dense(40 << 10), 8, 5},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.tr.parallelWorkers(tc.input, tc.maxProcs); got != tc.want {
+				t.Errorf("parallelWorkers(len=%d, maxProcs=%d) = %d, want %d",
+					len(tc.input), tc.maxProcs, got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
> **Stack 5/20** · base: `perf/11-dual-density-dispatch` · commit: `70a9854`
> Combined perf chain (three research lines consolidated). Review index with per-PR A/B evidence, risk map, and merge order: [PR-CHAIN.md](https://github.com/ahrav/aho-corasick/blob/docs/27-chain-index/PR-CHAIN.md)

The parallel scan used to engage at 16KB for every automaton. Measured
crossovers on Zen 4 disagree: sparse text on the single-stop-byte
automaton scans ~2GB/s serially, and goroutine startup, overlap
re-scans, and merge fan-in only pay off near 128KB (sequential wins
12-28% at 16-96KB). Table-path automata and stop-byte-dense input scan
several-fold slower, so 32KB is the right floor there. Reuses the
looksDense sampler to pick the threshold per input.

Benchmarks (vs parent, n=6): 32KB -32%, 64KB -36%, 100KB -25% on the
sparse single-stop automaton; dense and table paths unchanged.

