### PR TITLE
perf: dual-cursor scans for the multi-stop table paths

### DIFF
--- a/differential32_test.go
+++ b/differential32_test.go
@@ -1,0 +1,96 @@
+package ahocorasick
+
+import (
+	"math/rand"
+	"testing"
+)
+
+// TestDifferential32BitPaths forces the full-width (32-bit) scan paths by
+// dropping the failTrans16 acceleration table, then cross-checks Match
+// against the naive reference. Real automata only take these paths above
+// 2^15 states, which is too large to differential-test directly; the
+// scan code is byte-for-byte the same either way, so this whitebox
+// downgrade gives the 32-bit loops (matchStopByte, matchTable,
+// matchDualTable32, scanRangeTable32) the same coverage as the 16-bit
+// ones.
+func TestDifferential32BitPaths(t *testing.T) {
+	rng := rand.New(rand.NewSource(99))
+
+	cases := []struct {
+		name     string
+		patterns []string
+		mkInput  func(n int) []byte
+	}{
+		{
+			// Single stop byte: all patterns start with 'a'.
+			"single-stop",
+			[]string{"ab", "abc", "abca", "aa", "aab"},
+			func(n int) []byte {
+				input := make([]byte, n)
+				for i := range input {
+					if rng.Intn(3) == 0 {
+						input[i] = 'a'
+					} else {
+						input[i] = byte('b' + rng.Intn(20))
+					}
+				}
+				return input
+			},
+		},
+		{
+			// Several stop bytes, sparse input: table paths, low density.
+			"multi-stop-sparse",
+			[]string{"ab", "bc", "ca", "abc", "cab"},
+			func(n int) []byte {
+				input := make([]byte, n)
+				for i := range input {
+					if rng.Intn(6) == 0 {
+						input[i] = byte('a' + rng.Intn(3))
+					} else {
+						input[i] = byte('x' + rng.Intn(8))
+					}
+				}
+				return input
+			},
+		},
+		{
+			// Several stop bytes, dense input: exercises the dual-cursor
+			// 32-bit table scan (rootDense passes).
+			"multi-stop-dense",
+			[]string{"ab", "bc", "ca", "abc", "cab", "bbb"},
+			func(n int) []byte {
+				input := make([]byte, n)
+				for i := range input {
+					input[i] = byte('a' + rng.Intn(3))
+				}
+				return input
+			},
+		},
+	}
+
+	sizes := []int{0, 1, 100, 1000, 4096, 5000, 20000, 80000}
+
+	for _, c := range cases {
+		trie := NewTrieBuilder().AddStrings(c.patterns).Build()
+		trie.failTrans16 = nil // force 32-bit scan paths
+		trie.setStopEntry()
+
+		for _, size := range sizes {
+			input := c.mkInput(size)
+			want := naiveMatch(c.patterns, input)
+			got := trie.Match(input)
+
+			if len(got) != len(want) {
+				t.Fatalf("%s size=%d: got %d matches, want %d", c.name, size, len(got), len(want))
+			}
+			for k, m := range got {
+				w := want[k]
+				if m.Pos() != w[0] || m.Pattern() != w[1] || uint32(len(m.Match())) != w[2] {
+					t.Fatalf("%s size=%d match %d: got (pos=%d pat=%d len=%d), want (pos=%d pat=%d len=%d)",
+						c.name, size, k, m.Pos(), m.Pattern(), len(m.Match()), w[0], w[1], w[2])
+				}
+			}
+			trie.ReleaseMatches(got)
+		}
+	}
+}

--- a/differential32_test.go
+++ b/differential32_test.go
@@ -66,9 +66,44 @@ func TestDifferential32BitPaths(t *testing.T) {
 				return input
 			},
 		},
+		{
+			// Dense sample windows but asymmetric root gaps: the first
+			// half is ~half filler while the second half is nearly all
+			// stop bytes, so rootDense still passes but lane A root-skips
+			// through its gaps and exits the interleaved loop early,
+			// leaving scanRangeTable32 a substantial lane-B remainder
+			// with gaps of its own — the skipRootTable and early-return
+			// branches the lockstep dense case can never reach. A
+			// pattern planted across mid pins the lane boundary: matches
+			// ending < mid belong to lane A, >= mid to lane B.
+			"multi-stop-gappy",
+			[]string{"ab", "bc", "ca", "abc", "cab", "bbb"},
+			func(n int) []byte {
+				input := make([]byte, n)
+				for i := range input {
+					gap := 8 // first half: ~half the bytes are root gaps
+					if i >= n/2 {
+						gap = 14 // second half: occasional gaps only
+					}
+					if rng.Intn(16) < gap {
+						input[i] = byte('a' + rng.Intn(3))
+					} else {
+						input[i] = byte('x' + rng.Intn(8))
+					}
+				}
+				if n >= 8 {
+					copy(input[n/2-1:], "cab")
+					// Deterministic filler tail: the lane-B finisher's
+					// root skip finds no further stop byte and takes the
+					// i >= to early return.
+					input[n-2], input[n-1] = 'x', 'y'
+				}
+				return input
+			},
+		},
 	}
 
-	sizes := []int{0, 1, 100, 1000, 4096, 5000, 20000, 80000}
+	sizes := []int{0, 1, 100, 1000, 4096, 5000, 8191, 20000, 80000}
 
 	for _, c := range cases {
 		trie := NewTrieBuilder().AddStrings(c.patterns).Build()

--- a/differential32_test.go
+++ b/differential32_test.go
@@ -101,6 +101,27 @@ func TestDifferential32BitPaths(t *testing.T) {
 				return input
 			},
 		},
+		{
+			// A long root gap spanning mid: rootDense still passes on
+			// the dense head/tail windows, lane A's bounded root skip
+			// stops at exactly mid, and lane B enters mid-gap and skips
+			// to the gap's far edge — the lane-boundary geometry the
+			// other fixtures never produce.
+			"multi-stop-midgap",
+			[]string{"ab", "bc", "ca", "abc", "cab", "bbb"},
+			func(n int) []byte {
+				input := make([]byte, n)
+				for i := range input {
+					input[i] = byte('a' + rng.Intn(3))
+				}
+				if n >= 1024 {
+					for i := n/2 - 200; i < n/2+200; i++ {
+						input[i] = 'z'
+					}
+				}
+				return input
+			},
+		},
 	}
 
 	sizes := []int{0, 1, 100, 1000, 4096, 5000, 8191, 20000, 80000}

--- a/trie.go
+++ b/trie.go
@@ -908,7 +908,9 @@ func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 
 // scanRangeTable16 runs the multi-stop-byte automaton over input[i:to),
 // starting in state s, appending matches that end at or after minEmit to
-// raw, which is returned. Positions are absolute into input. Loads use
+// raw, which is returned. Positions are absolute into input. The root
+// skip is bounded to input[:to]: bytes past to belong to the other lane,
+// and a root gap carries no automaton state worth keeping. Loads use
 // raw pointer arithmetic; see matchStopByte.
 func (tr *Trie) scanRangeTable16(input []byte, i, to int, s uint32, minEmit int, raw []uint64) []uint64 {
 	ftBase := unsafe.Pointer(&tr.failTrans16[0])
@@ -918,7 +920,7 @@ func (tr *Trie) scanRangeTable16(input []byte, i, to int, s uint32, minEmit int,
 	for ; i < to; i++ {
 		if s == rootState {
 			if tr.rootStop[input[i]] == 0 {
-				i = tr.skipRootTable(input, i)
+				i = tr.skipRootTable(input[:to], i)
 			}
 			if i >= to {
 				return raw
@@ -948,7 +950,7 @@ func (tr *Trie) scanRangeTable32(input []byte, i, to int, s uint32, minEmit int,
 	for ; i < to; i++ {
 		if s == rootState {
 			if tr.rootStop[input[i]] == 0 {
-				i = tr.skipRootTable(input, i)
+				i = tr.skipRootTable(input[:to], i)
 			}
 			if i >= to {
 				return raw
@@ -991,8 +993,12 @@ func (tr *Trie) matchDualTable16(input []byte, buf *matchBuf) {
 
 	for iA < mid && iB < inputLen {
 		// Lane A: one step — a whole root gap skip, or one transition.
+		// The gap search is bounded to lane A's half: a root gap
+		// carries no automaton state, so bytes at or past mid are lane
+		// B's alone (unbounded, a gap crossing mid would scan lane B's
+		// half twice); see matchDualStopByte16.
 		if sA == rootState && tr.rootStop[input[iA]] == 0 {
-			iA = tr.skipRootTable(input, iA)
+			iA = tr.skipRootTable(input[:mid], iA)
 		} else {
 			v := uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(sA)<<9+uintptr(input[iA])<<1)))
 			sA = v &^ (1 << 15)
@@ -1051,8 +1057,10 @@ func (tr *Trie) matchDualTable32(input []byte, buf *matchBuf) {
 	rawA, rawB := buf.raw, buf.raw2
 
 	for iA < mid && iB < inputLen {
+		// Lane A's gap search is bounded to its half; see
+		// matchDualTable16.
 		if sA == rootState && tr.rootStop[input[iA]] == 0 {
-			iA = tr.skipRootTable(input, iA)
+			iA = tr.skipRootTable(input[:mid], iA)
 		} else {
 			v := *(*uint32)(unsafe.Add(ftBase, uintptr(sA)<<10+uintptr(input[iA])<<2))
 			sA = v & stateMask

--- a/trie.go
+++ b/trie.go
@@ -645,6 +645,44 @@ func looksDense(input []byte, c byte) bool {
 	return k*4 >= dualDenseThreshold*3
 }
 
+// dualTableMin is the minimum input size for the dual-cursor table
+// scans: below it the rootDense sampling cost is a meaningful fraction
+// of the whole scan.
+const dualTableMin = 4096
+
+// rootDenseThreshold is the minimum number of root-leaving bytes in the
+// 768 sampled by rootDense (~28%) for the dual-cursor table scan.
+// Measured on Zen 4: natural text over the multi-stop word automata
+// samples at 15-20% (single-cursor wins by ~5%), concatenated dictionary
+// words at ~38% (dual wins by 35-43%).
+const rootDenseThreshold = 215
+
+// rootDense samples three 256-byte windows of input (head, middle, tail)
+// and reports whether enough bytes leave the root state for the
+// dual-cursor table scan to pay. Windows, not strided points, so
+// periodic inputs do not alias against the sample pattern.
+func (tr *Trie) rootDense(input []byte) bool {
+	rootStop := &tr.rootStop
+	n := len(input)
+	k := 0
+	for _, b := range input[:256] {
+		k += int(rootStop[b])
+	}
+	// A dense input with a near-empty head window is pathological;
+	// bail before sampling the other windows. Misclassification only
+	// picks the single-cursor loop, never wrong results.
+	if k < 8 {
+		return false
+	}
+	mid, tail := n/2-128, n-256
+	for _, w := range [2]int{mid, tail} {
+		for _, b := range input[w : w+256] {
+			k += int(rootStop[b])
+		}
+	}
+	return k >= rootDenseThreshold
+}
+
 // matchSeq scans input sequentially into buf.
 func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 	if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 {
@@ -663,10 +701,203 @@ func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 	if len(tr.rootStopBytes) == 1 {
 		tr.matchStopByte(input, buf)
 	} else if tr.failTrans16 != nil {
-		tr.matchTable16(input, buf)
+		if len(input) >= dualTableMin && int(tr.maxLen)*4 < len(input)/2 && tr.rootDense(input) {
+			tr.matchDualTable16(input, buf)
+		} else {
+			tr.matchTable16(input, buf)
+		}
 	} else {
-		tr.matchTable(input, buf)
+		if len(input) >= dualTableMin && int(tr.maxLen)*4 < len(input)/2 && tr.rootDense(input) {
+			tr.matchDualTable32(input, buf)
+		} else {
+			tr.matchTable(input, buf)
+		}
 	}
+}
+
+// scanRangeTable16 runs the multi-stop-byte automaton over input[i:to),
+// starting in state s, appending matches that end at or after minEmit to
+// raw, which is returned. Positions are absolute into input. Loads use
+// raw pointer arithmetic; see matchStopByte.
+func (tr *Trie) scanRangeTable16(input []byte, i, to int, s uint32, minEmit int, raw []uint64) []uint64 {
+	ftBase := unsafe.Pointer(&tr.failTrans16[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
+
+	for ; i < to; i++ {
+		if s == rootState {
+			if tr.rootStop[input[i]] == 0 {
+				i = tr.skipRootTable(input, i)
+			}
+			if i >= to {
+				return raw
+			}
+		}
+
+		v := uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(s)<<9+uintptr(input[i])<<1)))
+		s = v &^ (1 << 15)
+		if v&(1<<15) != 0 && i >= minEmit {
+			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 {
+				raw = append(raw, uint64(i), dp)
+			}
+			for u := *(*uint32)(unsafe.Add(dlBase, uintptr(s)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+				raw = append(raw, uint64(i), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+			}
+		}
+	}
+	return raw
+}
+
+// scanRangeTable32 is scanRangeTable16 on the full-width failTrans table.
+func (tr *Trie) scanRangeTable32(input []byte, i, to int, s uint32, minEmit int, raw []uint64) []uint64 {
+	ftBase := unsafe.Pointer(&tr.failTrans[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
+
+	for ; i < to; i++ {
+		if s == rootState {
+			if tr.rootStop[input[i]] == 0 {
+				i = tr.skipRootTable(input, i)
+			}
+			if i >= to {
+				return raw
+			}
+		}
+
+		v := *(*uint32)(unsafe.Add(ftBase, uintptr(s)<<10+uintptr(input[i])<<2))
+		s = v & stateMask
+		if v&outputFlag != 0 && i >= minEmit {
+			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 {
+				raw = append(raw, uint64(i), dp)
+			}
+			for u := *(*uint32)(unsafe.Add(dlBase, uintptr(s)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+				raw = append(raw, uint64(i), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+			}
+		}
+	}
+	return raw
+}
+
+// matchDualTable16 is the multi-stop-byte analog of matchDualStopByte16:
+// two independent cursors interleave over the two halves of input so
+// their serial transition-load chains overlap. Lane B starts maxLen-1
+// bytes before the midpoint and emits only matches ending at or after it
+// (see matchParallel for why that overlap suffices), so rawA followed by
+// rawB is exactly a sequential scan's output. Root gaps are skipped with
+// the rootStop table since several byte values leave the root.
+func (tr *Trie) matchDualTable16(input []byte, buf *matchBuf) {
+	ftBase := unsafe.Pointer(&tr.failTrans16[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
+
+	inputLen := len(input)
+	mid := inputLen / 2
+	startB := max(mid-int(tr.maxLen)+1, 0)
+
+	sA, sB := rootState, rootState
+	iA, iB := 0, startB
+	rawA, rawB := buf.raw, buf.raw2
+
+	for iA < mid && iB < inputLen {
+		// Lane A: one step — a whole root gap skip, or one transition.
+		if sA == rootState && tr.rootStop[input[iA]] == 0 {
+			iA = tr.skipRootTable(input, iA)
+		} else {
+			v := uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(sA)<<9+uintptr(input[iA])<<1)))
+			sA = v &^ (1 << 15)
+			if v&(1<<15) != 0 {
+				if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(sA)<<3)); uint32(dp) != 0 {
+					rawA = append(rawA, uint64(iA), dp)
+				}
+				for u := *(*uint32)(unsafe.Add(dlBase, uintptr(sA)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+					rawA = append(rawA, uint64(iA), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+				}
+			}
+			iA++
+		}
+
+		// Lane B: same step shape.
+		if sB == rootState && tr.rootStop[input[iB]] == 0 {
+			iB = tr.skipRootTable(input, iB)
+		} else {
+			v := uint32(*(*uint16)(unsafe.Add(ftBase, uintptr(sB)<<9+uintptr(input[iB])<<1)))
+			sB = v &^ (1 << 15)
+			if v&(1<<15) != 0 && iB >= mid {
+				if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(sB)<<3)); uint32(dp) != 0 {
+					rawB = append(rawB, uint64(iB), dp)
+				}
+				for u := *(*uint32)(unsafe.Add(dlBase, uintptr(sB)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+					rawB = append(rawB, uint64(iB), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+				}
+			}
+			iB++
+		}
+	}
+
+	// Finish whichever lane has input left.
+	rawA = tr.scanRangeTable16(input, iA, mid, sA, 0, rawA)
+	rawB = tr.scanRangeTable16(input, iB, inputLen, sB, mid, rawB)
+
+	// Concatenate: lane A ends < mid, lane B ends >= mid, so order is
+	// exactly the sequential scan's.
+	buf.raw = append(rawA, rawB...)
+	buf.raw2 = rawB[:0]
+}
+
+// matchDualTable32 is matchDualTable16 on the full-width failTrans table
+// (automata with too many states for 15-bit ids).
+func (tr *Trie) matchDualTable32(input []byte, buf *matchBuf) {
+	ftBase := unsafe.Pointer(&tr.failTrans[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
+
+	inputLen := len(input)
+	mid := inputLen / 2
+	startB := max(mid-int(tr.maxLen)+1, 0)
+
+	sA, sB := rootState, rootState
+	iA, iB := 0, startB
+	rawA, rawB := buf.raw, buf.raw2
+
+	for iA < mid && iB < inputLen {
+		if sA == rootState && tr.rootStop[input[iA]] == 0 {
+			iA = tr.skipRootTable(input, iA)
+		} else {
+			v := *(*uint32)(unsafe.Add(ftBase, uintptr(sA)<<10+uintptr(input[iA])<<2))
+			sA = v & stateMask
+			if v&outputFlag != 0 {
+				if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(sA)<<3)); uint32(dp) != 0 {
+					rawA = append(rawA, uint64(iA), dp)
+				}
+				for u := *(*uint32)(unsafe.Add(dlBase, uintptr(sA)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+					rawA = append(rawA, uint64(iA), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+				}
+			}
+			iA++
+		}
+
+		if sB == rootState && tr.rootStop[input[iB]] == 0 {
+			iB = tr.skipRootTable(input, iB)
+		} else {
+			v := *(*uint32)(unsafe.Add(ftBase, uintptr(sB)<<10+uintptr(input[iB])<<2))
+			sB = v & stateMask
+			if v&outputFlag != 0 && iB >= mid {
+				if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(sB)<<3)); uint32(dp) != 0 {
+					rawB = append(rawB, uint64(iB), dp)
+				}
+				for u := *(*uint32)(unsafe.Add(dlBase, uintptr(sB)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+					rawB = append(rawB, uint64(iB), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+				}
+			}
+			iB++
+		}
+	}
+
+	rawA = tr.scanRangeTable32(input, iA, mid, sA, 0, rawA)
+	rawB = tr.scanRangeTable32(input, iB, inputLen, sB, mid, rawB)
+
+	buf.raw = append(rawA, rawB...)
+	buf.raw2 = rawB[:0]
 }
 
 // scanRange16 runs the stop-byte automaton over input[i:to), starting in


### PR DESCRIPTION
> **Stack 8/20** · base: `perf/14-skip-indexbyte-escape` · commit: `d4ba767`
> Combined perf chain (three research lines consolidated). Review index with per-PR A/B evidence, risk map, and merge order: [PR-CHAIN.md](https://github.com/ahrav/aho-corasick/blob/docs/27-chain-index/PR-CHAIN.md)

Extend the dual-cursor idea (two independent automaton cursors over the
two input halves, overlapping their serial transition-load latencies) to
the multi-stop-byte table paths, in 16-bit and 32-bit variants. Lane B
starts maxLen-1 bytes before the midpoint and emits only matches ending
at or after it, so lane A's output followed by lane B's is exactly the
sequential scan's (the matchParallel overlap argument).

Dispatch is by sampled root-leaving density: three 256-byte windows of
rootStop lookups (~28% threshold, early-out on a near-empty head
window). Natural text samples at 15-20% and keeps the single-cursor
loop; concatenated dictionary words sample at ~38%, where the dual scan
wins large. Only inputs >=4KB are considered so the sampling cost stays
negligible. Misclassification only affects speed, never output.

Adds a whitebox differential test that forces the 32-bit paths (real
tries only reach them above 2^15 states) against the naive reference.

Benchmarks (vs parent, n=6-8): dense multi-stop input -36..-43%;
natural text and no-match inputs unchanged (within +-2%).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved matching performance for inputs with dense root-level transitions.
  * Added optimized scanning paths for both smaller and larger transition tables.
  * Preserved correct match ordering across optimized split scans.

* **Tests**
  * Added differential coverage for 32-bit matching paths across randomized patterns and input sizes.
  * Verifies match positions, pattern identifiers, lengths, and total match counts against a reference matcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->