### PR TITLE
perf: byte-class-compressed transition table for large tries

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -272,6 +272,13 @@ func (tb *TrieBuilder) Build() *Trie {
 	trie.addOutputFlags()
 	trie.buildRootSkip()
 	trie.buildFailTrans16()
+	var live [256]bool
+	for _, s := range tb.states {
+		for _, t := range s.children {
+			live[t.value] = true
+		}
+	}
+	trie.buildClassTable(&live)
 	trie.setStopEntry()
 
 	return trie

--- a/builder.go
+++ b/builder.go
@@ -272,13 +272,18 @@ func (tb *TrieBuilder) Build() *Trie {
 	trie.addOutputFlags()
 	trie.buildRootSkip()
 	trie.buildFailTrans16()
-	var live [256]bool
-	for _, s := range tb.states {
-		for _, t := range s.children {
-			live[t.value] = true
+	// Compute the live-byte set only when a scan path exists to read the
+	// class table; single-stop and failTrans16 tries never load it, and
+	// building it anyway would retain up to 512B/state of dead weight.
+	if trie.classTableUsable() {
+		var live [256]bool
+		for _, s := range tb.states {
+			for _, t := range s.children {
+				live[t.value] = true
+			}
 		}
+		trie.buildClassTable(&live)
 	}
-	trie.buildClassTable(&live)
 	trie.setStopEntry()
 
 	return trie

--- a/differential32_test.go
+++ b/differential32_test.go
@@ -77,10 +77,16 @@ func TestDifferential32BitPaths(t *testing.T) {
 			trie.setStopEntry()
 			if classed {
 				// Also exercise the byte-class-compressed loops
-				// (matchTableC, matchDualTableC, scanRangeTableC).
+				// (matchDualTableC, scanRangeTableC). Single-stop
+				// tries take matchStopByte and never read the class
+				// table, so buildClassTable must refuse to build one
+				// for them; there is no classed path to exercise.
 				trie.buildClassTable(trie.derivedLiveBytes())
+				if wantTable := len(trie.rootStopBytes) != 1; (trie.failTransC != nil) != wantTable {
+					t.Fatalf("%s: failTransC != nil is %v, want %v", c.name, !wantTable, wantTable)
+				}
 				if trie.failTransC == nil {
-					t.Fatalf("%s: expected class table for small alphabet", c.name)
+					continue
 				}
 			} else {
 				trie.failTransC = nil

--- a/differential32_test.go
+++ b/differential32_test.go
@@ -71,26 +71,38 @@ func TestDifferential32BitPaths(t *testing.T) {
 	sizes := []int{0, 1, 100, 1000, 4096, 5000, 20000, 80000}
 
 	for _, c := range cases {
-		trie := NewTrieBuilder().AddStrings(c.patterns).Build()
-		trie.failTrans16 = nil // force 32-bit scan paths
-		trie.setStopEntry()
-
-		for _, size := range sizes {
-			input := c.mkInput(size)
-			want := naiveMatch(c.patterns, input)
-			got := trie.Match(input)
-
-			if len(got) != len(want) {
-				t.Fatalf("%s size=%d: got %d matches, want %d", c.name, size, len(got), len(want))
-			}
-			for k, m := range got {
-				w := want[k]
-				if m.Pos() != w[0] || m.Pattern() != w[1] || uint32(len(m.Match())) != w[2] {
-					t.Fatalf("%s size=%d match %d: got (pos=%d pat=%d len=%d), want (pos=%d pat=%d len=%d)",
-						c.name, size, k, m.Pos(), m.Pattern(), len(m.Match()), w[0], w[1], w[2])
+		for _, classed := range []bool{false, true} {
+			trie := NewTrieBuilder().AddStrings(c.patterns).Build()
+			trie.failTrans16 = nil // force 32-bit scan paths
+			trie.setStopEntry()
+			if classed {
+				// Also exercise the byte-class-compressed loops
+				// (matchTableC, matchDualTableC, scanRangeTableC).
+				trie.buildClassTable(trie.derivedLiveBytes())
+				if trie.failTransC == nil {
+					t.Fatalf("%s: expected class table for small alphabet", c.name)
 				}
+			} else {
+				trie.failTransC = nil
 			}
-			trie.ReleaseMatches(got)
+
+			for _, size := range sizes {
+				input := c.mkInput(size)
+				want := naiveMatch(c.patterns, input)
+				got := trie.Match(input)
+
+				if len(got) != len(want) {
+					t.Fatalf("%s classed=%v size=%d: got %d matches, want %d", c.name, classed, size, len(got), len(want))
+				}
+				for k, m := range got {
+					w := want[k]
+					if m.Pos() != w[0] || m.Pattern() != w[1] || uint32(len(m.Match())) != w[2] {
+						t.Fatalf("%s classed=%v size=%d match %d: got (pos=%d pat=%d len=%d), want (pos=%d pat=%d len=%d)",
+							c.name, classed, size, k, m.Pos(), m.Pattern(), len(m.Match()), w[0], w[1], w[2])
+					}
+				}
+				trie.ReleaseMatches(got)
+			}
 		}
 	}
 }

--- a/stream.go
+++ b/stream.go
@@ -31,8 +31,12 @@ func Decode(r io.Reader) (*Trie, error) {
 // DecodeWithMaxStates is Decode with a caller-supplied ceiling on the number of
 // automaton states. The bound caps the memory a corrupt or hostile stream can
 // make Decode allocate — failTrans costs one [256]uint32 row (1 KiB) per state
-// — so choose a value the process can afford. A non-positive maxStates falls
-// back to DecodeMaxStates.
+// — so choose a value the process can afford. Derived acceleration tables stay
+// within the same budget: the byte-class-compressed table a large trie may
+// rebuild after decoding (at most 512 B per state) is built only when it fits
+// in the headroom between the actual state count and maxStates, so total table
+// memory never exceeds maxStates KiB. A non-positive maxStates falls back to
+// DecodeMaxStates.
 func DecodeWithMaxStates(r io.Reader, maxStates int) (*Trie, error) {
 	dec := newDecoder(r)
 	return dec.decode(maxStates)
@@ -235,8 +239,23 @@ func (dec *decoder) decode(maxStates int) (*Trie, error) {
 	trie.addOutputFlags()
 	trie.buildRootSkip()
 	trie.buildFailTrans16()
-	if trie.failTrans16 == nil {
-		trie.buildClassTable(trie.derivedLiveBytes())
+	if trie.classTableUsable() {
+		// The maxStates contract prices decode memory in failTrans rows:
+		// 1 KiB per state, at most maxStates states. failTransC is on
+		// top of that, so build it only from budget the cap leaves
+		// unused — stride*4 bytes per state must fit in the
+		// (maxStates - states) KiB of headroom — keeping total table
+		// memory within the maxStates KiB the caller signed up for.
+		// spare cannot underflow: failTransLen <= maxStates was checked
+		// above. The spare >= failTransLen short-circuit is exact (the
+		// class row is at most half the 1 KiB full row) and keeps
+		// spare*1024 from overflowing under absurd caller-picked caps.
+		live := trie.derivedLiveBytes()
+		spare := uint64(maxStates) - failTransLen
+		if stride := classTableStride(live); stride != 0 &&
+			(spare >= failTransLen || uint64(stride*4)*failTransLen <= spare*1024) {
+			trie.buildClassTable(live)
+		}
 	}
 	trie.setStopEntry()
 	return trie, nil

--- a/stream.go
+++ b/stream.go
@@ -235,6 +235,9 @@ func (dec *decoder) decode(maxStates int) (*Trie, error) {
 	trie.addOutputFlags()
 	trie.buildRootSkip()
 	trie.buildFailTrans16()
+	if trie.failTrans16 == nil {
+		trie.buildClassTable(trie.derivedLiveBytes())
+	}
 	trie.setStopEntry()
 	return trie, nil
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -266,6 +266,55 @@ func TestDecodeWithMaxStatesEnforcesCallerLimit(t *testing.T) {
 	}
 }
 
+// TestDecodeClassTableRespectsMaxStatesBudget checks that the derived
+// byte-class-compressed table cannot push decode memory past the documented
+// maxStates budget of 1 KiB (one failTrans row) per state: with no headroom
+// between the actual state count and maxStates the table must be skipped,
+// and with ample headroom it must be built. The trie needs >2^15 states so
+// failTrans16 is nil (otherwise no class table is ever built) and a
+// multi-byte root fan-out so a scan path exists to consume it.
+func TestDecodeClassTableRespectsMaxStatesBudget(t *testing.T) {
+	const n = 1<<15 + 1 // one past the failTrans16 limit
+
+	failTrans := make([][256]uint32, n)
+	for s := range failTrans {
+		for b := range 256 {
+			failTrans[s][b] = rootState
+		}
+	}
+	// Two root-leaving bytes: rootStopBytes stays empty (multi-stop), so
+	// the class-table scan paths are reachable and classTableUsable holds.
+	failTrans[rootState]['a'] = 2
+	failTrans[rootState]['b'] = 3
+
+	dict := make([]uint32, n)
+	dictLink := make([]uint32, n)
+	pattern := make([]uint32, n)
+
+	// maxStates == state count: zero headroom, the class table must not
+	// be built on top of the failTrans budget.
+	tight, err := DecodeWithMaxStates(encodeRaw(t, dict, failTrans, dictLink, pattern), n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tight.failTrans16 != nil {
+		t.Fatalf("failTrans16 built for %d states, want nil above the 2^15 limit", n)
+	}
+	if tight.failTransC != nil {
+		t.Fatal("class table built with zero maxStates headroom, want skipped")
+	}
+
+	// Double the budget: the ~16 B/state class table fits easily and
+	// must be built for scan parity with builder-produced tries.
+	roomy, err := DecodeWithMaxStates(encodeRaw(t, dict, failTrans, dictLink, pattern), 2*n)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if roomy.failTransC == nil {
+		t.Fatal("class table skipped despite ample maxStates headroom, want built")
+	}
+}
+
 // TestDecodeTruncatedBeforeFailTrans exercises the incremental failTrans path:
 // a stream that declares many states (within the limit) but is truncated after
 // the dict rows must return an error, never panic, without reserving the full

--- a/trie.go
+++ b/trie.go
@@ -202,11 +202,49 @@ func (tr *Trie) buildFailTrans16() {
 	}
 }
 
+// classTableUsable reports whether any scan path can consume failTransC.
+// Only the multi-stop table loops (matchDualTableC, scanRangeTableC) read
+// it: single-stop tries always take matchStopByte, and tries small enough
+// for failTrans16 use its half-width loops, so building the table for
+// either would retain up to classStrideMax*4 bytes per state that nothing
+// loads. Valid only after buildRootSkip and buildFailTrans16 have run.
+func (tr *Trie) classTableUsable() bool {
+	return tr.failTrans16 == nil && len(tr.rootStopBytes) != 1
+}
+
+// classStrideMax is the widest failTransC row buildClassTable accepts, in
+// entries. At half the full 256-entry row the compressed table stops
+// fitting meaningfully better in cache, so wider strides aren't built.
+const classStrideMax = 128
+
+// classTableStride returns the failTransC row stride a live set implies —
+// the class count (the shared dead class plus one class per live byte)
+// rounded up to a power of two — or 0 when the row would exceed
+// classStrideMax and buildClassTable declines to build. Callers can price
+// the table (len(failTrans) * stride * 4 bytes) before building it.
+func classTableStride(live *[256]bool) int {
+	numClasses := 1
+	for b := range 256 {
+		if live[b] {
+			numClasses++
+		}
+	}
+	stride := 1
+	for stride < numClasses {
+		stride <<= 1
+	}
+	if stride > classStrideMax {
+		return 0
+	}
+	return stride
+}
+
 // buildClassTable builds the byte-class-compressed transition table for
-// automata that cannot use failTrans16. Only worthwhile when the class
-// row is at most half the full row: beyond that the compressed table
-// stops fitting meaningfully better in cache. Idempotent; must run after
-// addOutputFlags (flags ride along in the copied entries).
+// automata that cannot use failTrans16, when a scan path exists to read
+// it (see classTableUsable) and the class row is at most half the full
+// row (see classTableStride). Idempotent; must run after addOutputFlags
+// (flags ride along in the copied entries) and after buildRootSkip and
+// buildFailTrans16 (classTableUsable reads their outputs).
 //
 // A byte is live iff some state moves on it — equivalently, iff it
 // appears in some pattern; every dead byte sends every state to the
@@ -214,7 +252,11 @@ func (tr *Trie) buildFailTrans16() {
 // already knows; the decoder derives it with derivedLiveBytes.
 func (tr *Trie) buildClassTable(live *[256]bool) {
 	tr.failTransC = nil
-	if tr.failTrans16 != nil {
+	if !tr.classTableUsable() {
+		return
+	}
+	stride := classTableStride(live)
+	if stride == 0 {
 		return
 	}
 
@@ -228,16 +270,7 @@ func (tr *Trie) buildClassTable(live *[256]bool) {
 		}
 	}
 
-	stride := 1
-	shift := uint32(0)
-	for stride < numClasses {
-		stride <<= 1
-		shift++
-	}
-	if stride > 128 {
-		return
-	}
-
+	shift := uint32(bits.TrailingZeros(uint(stride)))
 	tr.classShift = shift
 	// Only live columns need copying: dead columns are all class 0,
 	// pre-set to the root. Iterating the live list keeps this pass
@@ -263,7 +296,7 @@ func (tr *Trie) buildClassTable(live *[256]bool) {
 // (for decoded tries, where the builder's pattern knowledge is gone): a
 // byte is live iff any state's entry on it differs from a plain root
 // transition. Costs a full table scan; call only when buildClassTable
-// will actually build (failTrans16 == nil).
+// will actually build (classTableUsable returns true).
 func (tr *Trie) derivedLiveBytes() *[256]bool {
 	var live [256]bool
 	for s := range tr.failTrans {

--- a/trie.go
+++ b/trie.go
@@ -70,6 +70,19 @@ type Trie struct {
 	// on every root re-entry, cutting a serial L1 access.
 	stopEntry16 uint16
 
+	// failTransC is a byte-class-compressed copy of failTrans, built for
+	// automata too large for failTrans16 when few enough distinct byte
+	// values appear in the patterns. Bytes that appear in no pattern all
+	// behave identically (every state moves to the root), so one class
+	// column stands in for all of them; each pattern byte gets its own
+	// class. Rows shrink from 1KB to classStride*4 bytes, so the table
+	// the serial dependency chain loads from drops from hundreds of MB
+	// toward the L2/L3 sizes that dominate its latency. classOf maps an
+	// input byte to its class; classShift is log2 of the row stride.
+	failTransC []uint32
+	classOf    [256]uint8
+	classShift uint32
+
 	bufPool sync.Pool // Pool of *matchBuf
 }
 
@@ -187,6 +200,81 @@ func (tr *Trie) buildFailTrans16() {
 			tr.failTrans16[s<<8+b] = w
 		}
 	}
+}
+
+// buildClassTable builds the byte-class-compressed transition table for
+// automata that cannot use failTrans16. Only worthwhile when the class
+// row is at most half the full row: beyond that the compressed table
+// stops fitting meaningfully better in cache. Idempotent; must run after
+// addOutputFlags (flags ride along in the copied entries).
+//
+// A byte is live iff some state moves on it — equivalently, iff it
+// appears in some pattern; every dead byte sends every state to the
+// plain root and shares class 0. The builder passes the live set it
+// already knows; the decoder derives it with derivedLiveBytes.
+func (tr *Trie) buildClassTable(live *[256]bool) {
+	tr.failTransC = nil
+	if tr.failTrans16 != nil {
+		return
+	}
+
+	numClasses := 1
+	for b := range 256 {
+		if live[b] {
+			tr.classOf[b] = uint8(numClasses)
+			numClasses++
+		} else {
+			tr.classOf[b] = 0
+		}
+	}
+
+	stride := 1
+	shift := uint32(0)
+	for stride < numClasses {
+		stride <<= 1
+		shift++
+	}
+	if stride > 128 {
+		return
+	}
+
+	tr.classShift = shift
+	// Only live columns need copying: dead columns are all class 0,
+	// pre-set to the root. Iterating the live list keeps this pass
+	// O(states x liveBytes) instead of O(states x 256).
+	liveList := make([]int, 0, numClasses-1)
+	for b := range 256 {
+		if live[b] {
+			liveList = append(liveList, b)
+		}
+	}
+	tr.failTransC = make([]uint32, len(tr.failTrans)*stride)
+	for s := range tr.failTrans {
+		row := &tr.failTrans[s]
+		crow := tr.failTransC[s<<shift : s<<shift+stride]
+		crow[0] = rootState
+		for _, b := range liveList {
+			crow[tr.classOf[b]] = row[b]
+		}
+	}
+}
+
+// derivedLiveBytes recovers the live-byte set from a populated failTrans
+// (for decoded tries, where the builder's pattern knowledge is gone): a
+// byte is live iff any state's entry on it differs from a plain root
+// transition. Costs a full table scan; call only when buildClassTable
+// will actually build (failTrans16 == nil).
+func (tr *Trie) derivedLiveBytes() *[256]bool {
+	var live [256]bool
+	for s := range tr.failTrans {
+		row := &tr.failTrans[s]
+		for b := range 256 {
+			if row[b] != rootState {
+				live[b] = true
+			}
+		}
+	}
+	return &live
 }
 
 // setStopEntry caches the root transition on the single stop byte.
@@ -708,11 +796,104 @@ func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 		}
 	} else {
 		if len(input) >= dualTableMin && int(tr.maxLen)*4 < len(input)/2 && tr.rootDense(input) {
-			tr.matchDualTable32(input, buf)
+			if tr.failTransC != nil {
+				tr.matchDualTableC(input, buf)
+			} else {
+				tr.matchDualTable32(input, buf)
+			}
 		} else {
 			tr.matchTable(input, buf)
 		}
 	}
+}
+
+// scanRangeTableC is scanRangeTable32 on the class-compressed table.
+func (tr *Trie) scanRangeTableC(input []byte, i, to int, s uint32, minEmit int, raw []uint64) []uint64 {
+	ftBase := unsafe.Pointer(&tr.failTransC[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
+	classOf := &tr.classOf
+	shift := tr.classShift
+
+	for ; i < to; i++ {
+		if s == rootState {
+			if tr.rootStop[input[i]] == 0 {
+				i = tr.skipRootTable(input, i)
+			}
+			if i >= to {
+				return raw
+			}
+		}
+
+		v := *(*uint32)(unsafe.Add(ftBase, (uintptr(s)<<shift+uintptr(classOf[input[i]]))<<2))
+		s = v & stateMask
+		if v&outputFlag != 0 && i >= minEmit {
+			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 {
+				raw = append(raw, uint64(i), dp)
+			}
+			for u := *(*uint32)(unsafe.Add(dlBase, uintptr(s)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+				raw = append(raw, uint64(i), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+			}
+		}
+	}
+	return raw
+}
+
+// matchDualTableC is matchDualTable32 on the class-compressed table.
+func (tr *Trie) matchDualTableC(input []byte, buf *matchBuf) {
+	ftBase := unsafe.Pointer(&tr.failTransC[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
+	classOf := &tr.classOf
+	shift := tr.classShift
+
+	inputLen := len(input)
+	mid := inputLen / 2
+	startB := max(mid-int(tr.maxLen)+1, 0)
+
+	sA, sB := rootState, rootState
+	iA, iB := 0, startB
+	rawA, rawB := buf.raw, buf.raw2
+
+	for iA < mid && iB < inputLen {
+		if sA == rootState && tr.rootStop[input[iA]] == 0 {
+			iA = tr.skipRootTable(input, iA)
+		} else {
+			v := *(*uint32)(unsafe.Add(ftBase, (uintptr(sA)<<shift+uintptr(classOf[input[iA]]))<<2))
+			sA = v & stateMask
+			if v&outputFlag != 0 {
+				if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(sA)<<3)); uint32(dp) != 0 {
+					rawA = append(rawA, uint64(iA), dp)
+				}
+				for u := *(*uint32)(unsafe.Add(dlBase, uintptr(sA)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+					rawA = append(rawA, uint64(iA), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+				}
+			}
+			iA++
+		}
+
+		if sB == rootState && tr.rootStop[input[iB]] == 0 {
+			iB = tr.skipRootTable(input, iB)
+		} else {
+			v := *(*uint32)(unsafe.Add(ftBase, (uintptr(sB)<<shift+uintptr(classOf[input[iB]]))<<2))
+			sB = v & stateMask
+			if v&outputFlag != 0 && iB >= mid {
+				if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(sB)<<3)); uint32(dp) != 0 {
+					rawB = append(rawB, uint64(iB), dp)
+				}
+				for u := *(*uint32)(unsafe.Add(dlBase, uintptr(sB)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+					rawB = append(rawB, uint64(iB), *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3)))
+				}
+			}
+			iB++
+		}
+	}
+
+	rawA = tr.scanRangeTableC(input, iA, mid, sA, 0, rawA)
+	rawB = tr.scanRangeTableC(input, iB, inputLen, sB, mid, rawB)
+
+	buf.raw = append(rawA, rawB...)
+	buf.raw2 = rawB[:0]
 }
 
 // scanRangeTable16 runs the multi-stop-byte automaton over input[i:to),


### PR DESCRIPTION
> **Stack 9/20** · base: `perf/15-dual-table-scans` · commit: `6dd7cdd`
> Combined perf chain (three research lines consolidated). Review index with per-PR A/B evidence, risk map, and merge order: [PR-CHAIN.md](https://github.com/ahrav/aho-corasick/blob/docs/27-chain-index/PR-CHAIN.md)

Tries too large for 15-bit state ids scan through a table of 1KB rows
(185MB at 190k states), so dense input that walks deep into the
automaton pays L3/DRAM latency on nearly every byte. Bytes that appear
in no pattern behave identically from every state — they all fall back
to the root — so one class column stands in for all of them and each
pattern byte gets its own class. With Norwegian dictionary patterns
that is 32 columns instead of 256: 23MB instead of 185MB, and the class
lookup depends only on the input byte, off the serial chain.

The compressed table backs only the dense-dispatch branch
(matchDualTableC): on sparse text the hot shallow rows are already
cache-resident and the extra classOf load costs ~8%, while on dense
input the compression wins 28-38% on top of the dual-cursor gain. The
builder derives the live-byte set from the trie it just built; Decode
re-derives it with one table scan, only when the trie is large enough
to need it. Costs +12% trie memory on such tries.

Benchmarks (vs parent, n=6-8): dense multi-stop -28..-38% further
(compounded -54..-63% vs the pre-dual baseline); sparse text, no-match,
and small tries unchanged; 100k-pattern build 119ms -> 144ms.

