### PR TITLE
perf: raise the parallel worker cap to 32 for inputs >=256KB

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -706,6 +706,20 @@ func (tr *Trie) walkTable(input []byte, fn WalkFn) {
 // below it, goroutine startup outweighs the scan work.
 const parallelChunk = 8 << 10
 
+// parallelChunkWide is the minimum bytes of input per worker goroutine
+// beyond the base cap of 8 workers. With the materialize tail no longer
+// serial, scan throughput keeps scaling past 8 workers, but only once
+// each worker holds a slice large enough to amortize its wakeup and
+// merge fan-in; at parallelChunk-sized slices the extra workers cost
+// more than they scan (measured: 256KB across 32 workers runs ~25%
+// slower than across 8).
+const parallelChunkWide = 32 << 10
+
+// parallelWorkersMax is the worker cap once slices reach
+// parallelChunkWide: scan throughput saturates near 32 workers
+// (measured on 48-core Zen 4).
+const parallelWorkersMax = 32
+
 // parallelMin is the minimum input size for the parallel scan. The
 // table-path automata scan slowly enough serially that workers pay for
 // themselves from 32KB, as do the single-stop-byte automata on
@@ -731,15 +745,21 @@ func (tr *Trie) parallelWorkers(input []byte, maxProcs int) int {
 	if len(input) < parallelMin {
 		return 0
 	}
-	// The worker cap bounds wakeup and merge fan-in: 8 below 256KB,
-	// where each worker gets only a few KB of a fast scan, 32 above
-	// (scan throughput saturates near 32 workers, measured on 48-core
-	// Zen 4).
-	maxP := 8
-	if len(input) >= 256<<10 {
-		maxP = 32
+	// Cap at 8 workers while each holds only a few parallelChunk-sized
+	// KB: more of them mainly adds wakeup and steal latency while the
+	// merge fan-in grows. Ramp toward parallelWorkersMax as slices
+	// reach parallelChunkWide, where the extra workers amortize.
+	p := min(maxProcs, len(input)/parallelChunk, 8)
+	if wide := min(maxProcs, len(input)/parallelChunkWide, parallelWorkersMax); wide > p {
+		p = wide
 	}
-	p := min(maxProcs, len(input)/parallelChunk, maxP)
+	// Long patterns shrink the count further: matchParallel re-scans
+	// overlap := maxLen-1 bytes per chunk and falls back to a serial
+	// scan when overlap*4 > chunk, so keep every chunk at least four
+	// overlaps wide rather than losing parallelism outright.
+	if overlap := int(tr.maxLen) - 1; overlap > 0 {
+		p = min(p, len(input)/(overlap*4))
+	}
 	if p < 2 {
 		return 0
 	}

--- a/trie.go
+++ b/trie.go
@@ -690,9 +690,15 @@ func (tr *Trie) Match(input []byte) []*Match {
 			pmin = 128 << 10
 		}
 		if len(input) >= pmin {
-			// Cap at 8 workers: more of them mainly adds wakeup and
-			// steal latency while the post-scan merge is serial.
-			if p := min(runtime.GOMAXPROCS(0), len(input)/parallelChunk, 8); p > 1 {
+			// The worker cap bounds wakeup and merge fan-in: 8 below
+			// 256KB, where each worker gets only a few KB of a fast
+			// scan, 32 above (scan throughput saturates near 32
+			// workers, measured on 48-core Zen 4).
+			maxP := 8
+			if len(input) >= 256<<10 {
+				maxP = 32
+			}
+			if p := min(runtime.GOMAXPROCS(0), len(input)/parallelChunk, maxP); p > 1 {
 				return tr.matchParallel(input, p)
 			}
 		}

--- a/trie_test.go
+++ b/trie_test.go
@@ -378,6 +378,8 @@ func TestParallelWorkersPolicy(t *testing.T) {
 		{"workers capped by GOMAXPROCS", single, dense(40 << 10), 2, 2},
 		{"256KiB holds the base cap", single, dense(256 << 10), 64, 8},
 		{"extended cap ramps at parallelChunkWide per worker", single, dense(512 << 10), 64, 16},
+		{"extended cap reaches 32 at 1MiB", single, dense(1 << 20), 64, 32},
+		{"extended cap stays below 32 just under 1MiB", single, dense((1 << 20) - 8), 64, 31},
 		{"extended cap saturates at 32", single, dense(2 << 20), 64, 32},
 		{"extended cap bounded by GOMAXPROCS", single, dense(2 << 20), 12, 12},
 		{"long patterns shrink the cap to clear the overlap guard", long, sparse(256 << 10), 64, 7},

--- a/trie_test.go
+++ b/trie_test.go
@@ -339,6 +339,19 @@ func TestParallelWorkersPolicy(t *testing.T) {
 	}
 	big := buildBigSingleStopTrie(t)
 
+	// A table-path trie with a 9000-byte pattern: overlap*4 is 35996,
+	// so at 256KiB the overlap shrink caps the workers at
+	// 262144/35996 = 7 where the plain caps would allow 8.
+	long := NewTrieBuilder().AddStrings([]string{
+		strings.Repeat("x", 9000), "ab", "cd",
+	}).Build()
+	if len(long.rootStopBytes) == 1 {
+		t.Fatal("expected the long-pattern trie to skip the density gate")
+	}
+	if long.maxLen != 9000 {
+		t.Fatalf("expected maxLen 9000, got %d", long.maxLen)
+	}
+
 	// Stop byte 'a' at 1/16 bytes (~6%) sits under the ~10% density
 	// threshold; at 1/8 (~12.5%) it sits over.
 	sparse := func(size int) []byte {
@@ -363,6 +376,12 @@ func TestParallelWorkersPolicy(t *testing.T) {
 		{"table path parallelizes from parallelMin", multi, sparse(40 << 10), 8, 5},
 		{"workers capped at 8", single, dense(160 << 10), 16, 8},
 		{"workers capped by GOMAXPROCS", single, dense(40 << 10), 2, 2},
+		{"256KiB holds the base cap", single, dense(256 << 10), 64, 8},
+		{"extended cap ramps at parallelChunkWide per worker", single, dense(512 << 10), 64, 16},
+		{"extended cap saturates at 32", single, dense(2 << 20), 64, 32},
+		{"extended cap bounded by GOMAXPROCS", single, dense(2 << 20), 12, 12},
+		{"long patterns shrink the cap to clear the overlap guard", long, sparse(256 << 10), 64, 7},
+		{"overlap shrink below 2 workers stays sequential", long, sparse(64 << 10), 64, 0},
 		{"32-bit sparse below parallelSparseMin stays sequential", big, sparse(64 << 10), 8, 0},
 		{"32-bit sparse past parallelSparseMin parallelizes", big, sparse(160 << 10), 8, 8},
 		{"32-bit dense parallelizes from parallelMin", big, dense(40 << 10), 8, 5},


### PR DESCRIPTION
> **Stack 11/20** · base: `perf/17-parallel-materialize` · commit: `6dc3977`
> Combined perf chain (three research lines consolidated). Review index with per-PR A/B evidence, risk map, and merge order: [PR-CHAIN.md](https://github.com/ahrav/aho-corasick/blob/docs/27-chain-index/PR-CHAIN.md)

With the materialize tail no longer serial, scan throughput keeps
scaling past 8 workers on large inputs. Cap at 32 (saturation point
measured on 48-core Zen 4) once the input is large enough that each
worker still gets a meaningful slice; below 256KB keep 8, where wakeup
latency dominates.

Benchmarks (vs parent, n=6-8): 512KB -10..-22%, 2MB -21%, 8MB -34%;
sub-256KB inputs unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved parallel matching scalability for large inputs by supporting more workers when beneficial.
  * Added safeguards to cap worker usage and respect available system processing capacity.
  * Refined behavior for long patterns and overlapping matches, including cases where sequential processing is more efficient.

* **Tests**
  * Expanded coverage for worker scaling, maximum limits, system capacity constraints, and long-pattern matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->