### PR TITLE
perf: raw pointer loads in the 32-bit Walk paths

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -578,9 +578,9 @@ func (tr *Trie) walkTable16(input []byte, fn WalkFn) {
 // single byte value: the root skip is an inlined SWAR word scan with a
 // vectorized bytes.IndexByte fallback for long gaps.
 func (tr *Trie) walkStopByte(input []byte, fn WalkFn) {
-	failTrans := tr.failTrans
-	dictPat := tr.dictPat
-	dictLink := tr.dictLink
+	ftBase := unsafe.Pointer(&tr.failTrans[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
 
 	c := tr.rootStopBytes[0]
 	cc := uint64(c) * swarOnes
@@ -622,14 +622,14 @@ func (tr *Trie) walkStopByte(input []byte, fn WalkFn) {
 			}
 		}
 
-		v := failTrans[s][input[i]]
+		v := *(*uint32)(unsafe.Add(ftBase, uintptr(s)<<10+uintptr(input[i])<<2))
 		s = v & stateMask
 		if v&outputFlag != 0 {
-			if dp := dictPat[s]; uint32(dp) != 0 && !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
+			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 && !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
 				return
 			}
-			for u := dictLink[s]; u != nilState; u = dictLink[u] {
-				dp := dictPat[u]
+			for u := *(*uint32)(unsafe.Add(dlBase, uintptr(s)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+				dp := *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3))
 				if !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
 					return
 				}
@@ -641,9 +641,9 @@ func (tr *Trie) walkStopByte(input []byte, fn WalkFn) {
 // walkTable is Walk for tries with several root stop bytes, using the
 // rootStop table to skip root self-loops.
 func (tr *Trie) walkTable(input []byte, fn WalkFn) {
-	failTrans := tr.failTrans
-	dictPat := tr.dictPat
-	dictLink := tr.dictLink
+	ftBase := unsafe.Pointer(&tr.failTrans[0])
+	dpBase := unsafe.Pointer(&tr.dictPat[0])
+	dlBase := unsafe.Pointer(&tr.dictLink[0])
 
 	s := rootState
 
@@ -677,14 +677,14 @@ func (tr *Trie) walkTable(input []byte, fn WalkFn) {
 			}
 		}
 
-		v := failTrans[s][input[i]]
+		v := *(*uint32)(unsafe.Add(ftBase, uintptr(s)<<10+uintptr(input[i])<<2))
 		s = v & stateMask
 		if v&outputFlag != 0 {
-			if dp := dictPat[s]; uint32(dp) != 0 && !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
+			if dp := *(*uint64)(unsafe.Add(dpBase, uintptr(s)<<3)); uint32(dp) != 0 && !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
 				return
 			}
-			for u := dictLink[s]; u != nilState; u = dictLink[u] {
-				dp := dictPat[u]
+			for u := *(*uint32)(unsafe.Add(dlBase, uintptr(s)<<2)); u != nilState; u = *(*uint32)(unsafe.Add(dlBase, uintptr(u)<<2)) {
+				dp := *(*uint64)(unsafe.Add(dpBase, uintptr(u)<<3))
 				if !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
 					return
 				}


### PR DESCRIPTION
> **Stack 14/20** · base: `perf/20-skipbit-locate` · commit: `f2d5fa7`
> Combined perf chain (three research lines consolidated). Review index with per-PR A/B evidence, risk map, and merge order: [PR-CHAIN.md](https://github.com/ahrav/aho-corasick/blob/docs/27-chain-index/PR-CHAIN.md)

walkTable and walkStopByte still indexed failTrans/dictPat/dictLink
with bounds-checked slice expressions; every other scan loop already
uses raw pointer arithmetic under the documented all-entries-valid
invariant (state ids come from masking table entries the builder and
decoder populate for every slot — see matchStopByte). The checks sit
on the serial transition-load chain, where they cost most.

These are the loops behind Walk and MatchFirst on tries too large for
15-bit ids (>2^15 states), the one scan family the earlier walk16
commit could not cover.

Benchmarks (vs parent, n=6).

