### PR TITLE
test: sparse-trie anchor benchmark (negative-result pin)

### DIFF
--- a/bench_lab_test.go
+++ b/bench_lab_test.go
@@ -329,3 +329,15 @@ func BenchmarkLabNoMatchBig(b *testing.B) {
 		b.Run(fmt.Sprintf("multi-%dm", size>>20), func(b *testing.B) { benchMatch(b, trMulti, input[:size]) })
 	}
 }
+
+// Sparse-trie single-stop match: one multi-byte pattern over prose. The
+// depth-1 state has a single continuation byte, so nearly every stop
+// byte in the input is a false anchor — the regime the inert-pair
+// rejection targets. Stays under the dual/parallel thresholds via the
+// density dispatch (stop-byte density ~1%), so this exercises the
+// single-cursor matchStopByte16 loop.
+func BenchmarkLabAnchor(b *testing.B) {
+	_, ibsen := labLoad(b)
+	tr := NewTrieBuilder().AddString("Hedvig").Build()
+	b.Run("ibsen-100k", func(b *testing.B) { benchMatch(b, tr, ibsen[:100000]) })
+}


### PR DESCRIPTION
> **Stack 16/20** · base: `perf/22-retire-skip-sampler` · commit: `7a6274b`
> Combined perf chain (three research lines consolidated). Review index with per-PR A/B evidence, risk map, and merge order: [PR-CHAIN.md](https://github.com/ahrav/aho-corasick/blob/docs/27-chain-index/PR-CHAIN.md)

LabAnchor measures a one-pattern trie over prose: nearly every stop
byte is a false anchor. Pins the regime in which an inert-pair anchor
rejection (evaluated from the ac-lab research line, M-anchor) was
measured and rejected for this stack: with the IndexByte-escalated
root skip and the stopEntry16 constant, a false anchor already costs
two cheap steps, so the rejection won only -1.7% here while its
per-anchor check cost +7.6..8.7% on bushy-depth-1 tries (10k-word
dictionaries) even when a build-time gate kept it from ever firing.

