### PR TITLE
perf: single-pattern fast path with rare-byte and SWAR pair search

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -291,6 +291,7 @@ func (tb *TrieBuilder) Build() *Trie {
 		trie.buildClassTable(&live)
 	}
 	trie.setStopEntry()
+	trie.buildSinglePattern()
 
 	return trie
 }

--- a/single.go
+++ b/single.go
@@ -15,10 +15,12 @@ package ahocorasick
 //     starts per iteration, with no per-candidate restart cost.
 //     Throughput is flat (~3GB/s) regardless of candidate density.
 //
-// Each scan samples the rare byte's density and picks: rare-byte wins
-// when candidates are sparse, the pair scan when the "rare" byte is
-// locally common (e.g. prose, where every pattern byte is a frequent
-// letter).
+// Each scan picks by the rare byte's density: rare-byte wins when
+// candidates are sparse, the pair scan when the "rare" byte is locally
+// common (e.g. prose, where every pattern byte is a frequent letter).
+// The match path samples density up front (it scans everything anyway);
+// the callback walk decides inline from bytes already scanned, so an
+// early-terminating caller never pays for reads past its last match.
 //
 // bytes.Index is deliberately not used: on arm64 it generates candidates
 // from the first byte only, so a common-first-byte needle over prose
@@ -114,8 +116,6 @@ func (tr *Trie) buildSinglePattern() {
 		}
 		pat = append(pat, byte(found))
 	}
-	tr.single = pat
-	tr.singleDP = tr.dictPat[final]
 
 	// KMP prefix function: the minimal distance between overlapping
 	// occurrence starts is the period n - lps[n-1]. Advancing by it
@@ -131,6 +131,48 @@ func (tr *Trie) buildSinglePattern() {
 		}
 		lps[i] = k
 	}
+
+	// The checks above prove the shape (state count, outputs, one chain
+	// edge per state) but not the remaining row entries. Build always
+	// produces the canonical KMP automaton, but Decode accepts any
+	// in-range transition table, and a noncanonical one that passes the
+	// shape checks has different generic semantics than the recovered
+	// pattern (e.g. a final state whose row drops back to the root
+	// instead of re-entering the chain suppresses the second of two
+	// overlapping occurrences). Verify every remaining entry against
+	// the automaton the pattern implies, or leave the fast path off.
+	//
+	// Canonical rows, validated in state order so each state's fail row
+	// (depth lps[s-2], a state id strictly below s) is already known
+	// canonical when referenced: the root sends non-pattern bytes to
+	// itself, and every deeper state copies its fail state's row except
+	// at its chain byte.
+	for b := range 256 {
+		want := rootState
+		if byte(b) == pat[0] {
+			want = rootState + 1
+		}
+		if tr.failTrans[rootState][b]&stateMask != want {
+			return
+		}
+	}
+	for s := rootState + 1; s <= final; s++ {
+		row := &tr.failTrans[s]
+		failRow := &tr.failTrans[lps[s-2]+1]
+		d := int(s) - 1 // pattern bytes matched entering s
+		for b := range 256 {
+			want := failRow[b] & stateMask
+			if d < n && byte(b) == pat[d] {
+				want = s + 1
+			}
+			if row[b]&stateMask != want {
+				return
+			}
+		}
+	}
+
+	tr.single = pat
+	tr.singleDP = tr.dictPat[final]
 	tr.singleSkip = n - lps[n-1]
 
 	// Candidate filter offsets: the two lowest-ranked (rarest) pattern
@@ -188,6 +230,25 @@ func singleVerify(input []byte, pos int, p []byte) bool {
 		binary.LittleEndian.Uint64(input[pos+n-8:]) == binary.LittleEndian.Uint64(p[n-8:])
 }
 
+// singleVerifyCarry is singleVerify with a KMP-period carry: when the
+// previous confirmed match lies d < len(p) bytes back at a multiple of
+// the period (singleSkip), that match already proves the candidate's
+// first len(p)-d bytes — input[pos:prev+len(p)] equals p[d:] by the
+// previous match, and p[d:] equals p[:len(p)-d] because a multiple of
+// the period is itself a period — so only the last d bytes need
+// comparing. Without the carry, a periodic pattern over match-dense
+// input (m repeated a's over n repeated a's) re-verifies all m bytes at
+// each of the n overlapping occurrences, degrading the O(n) automaton
+// scan this path replaces to O(n*m); with it those tail compares sum to
+// O(n). prev < 0 means no previous match.
+func singleVerifyCarry(input []byte, pos, prev, skip int, p []byte) bool {
+	if d := pos - prev; prev >= 0 && d < len(p) && d%skip == 0 {
+		known := len(p) - d
+		return singleVerify(input, pos+known, p[known:])
+	}
+	return singleVerify(input, pos, p)
+}
+
 // singlePairDense reports whether rare-byte candidate density is high
 // enough that the flat-throughput SWAR pair scan beats IndexByte
 // candidate generation. Break-even (measured, Neoverse V1): rare-byte
@@ -195,15 +256,22 @@ func singleVerify(input []byte, pos int, p []byte) bool {
 // ~345ns/KB flat — so rare-byte loses above ~26 candidates per KB (~2.6%
 // density). Three 1KB windows (head, middle, tail) sample the density;
 // below 8KB the stakes are too small to pay for sampling.
+//
+// Only the match path uses this up-front sample: it scans the whole
+// input regardless, so touching the middle and tail windows early costs
+// nothing extra. The callback walk must stay lazy (a Walk callback may
+// stop at the first match — MatchFirst — so nothing may be read ahead
+// of the scan); singleRareWalk instead accumulates the same density
+// signal inline over the bytes already covered and switches mid-scan.
 func (tr *Trie) singlePairDense(input []byte) bool {
 	if len(input) < 8<<10 {
 		return false
 	}
 	c := tr.single[tr.singleO1 : tr.singleO1+1]
-	n := len(input)
-	k := bytes.Count(input[:1024], c)
-	k += bytes.Count(input[n/2:n/2+1024], c)
-	k += bytes.Count(input[n-1024:], c)
+	k := 0
+	for _, w := range sampleWindows(input) {
+		k += bytes.Count(w, c)
+	}
 	return k >= 78 // ~2.6% of the 3KB sampled
 }
 
@@ -230,7 +298,14 @@ func (tr *Trie) matchSingle(input []byte, buf *matchBuf) {
 	tr.singleRareMatch(input, buf)
 }
 
-// walkSingle is matchSingle for the callback API.
+// walkSingle is matchSingle for the callback API. Unlike matchSingle it
+// never samples density up front: the callback may stop the walk at the
+// first match (MatchFirst does), and an up-front head/middle/tail
+// sample would touch distant pages of a large cold input before a match
+// at offset zero could be delivered — the same rule the automaton walk
+// paths follow (see walkTable). singleRareWalk measures candidate
+// density inline over bytes it has already scanned and hands off to the
+// pair scan when the rare byte turns out to be locally common.
 func (tr *Trie) walkSingle(input []byte, fn WalkFn) {
 	if len(tr.single) == 1 {
 		c := tr.single[0]
@@ -246,10 +321,6 @@ func (tr *Trie) walkSingle(input []byte, fn WalkFn) {
 			}
 		}
 	}
-	if tr.singlePairDense(input) {
-		tr.singlePairWalk(input, fn)
-		return
-	}
 	tr.singleRareWalk(input, fn)
 }
 
@@ -262,6 +333,8 @@ func (tr *Trie) singleRareMatch(input []byte, buf *matchBuf) {
 	o1, o2 := tr.singleO1, tr.singleO2
 	c1, c2 := p[o1], p[o2]
 	dp := tr.singleDP
+	skip := tr.singleSkip
+	prev := -1 // last confirmed match start, for the period carry
 	for i := 0; i+n <= len(input); {
 		j := bytes.IndexByte(input[i+o1:], c1)
 		if j < 0 {
@@ -271,22 +344,39 @@ func (tr *Trie) singleRareMatch(input []byte, buf *matchBuf) {
 		if pos+n > len(input) {
 			return
 		}
-		if input[pos+o2] == c2 && singleVerify(input, pos, p) {
+		if input[pos+o2] == c2 && singleVerifyCarry(input, pos, prev, skip, p) {
 			buf.raw = append(buf.raw, uint64(pos+n-1), dp)
-			i = pos + tr.singleSkip
+			prev = pos
+			i = pos + skip
 		} else {
 			i = pos + 1
 		}
 	}
 }
 
-// singleRareWalk is singleRareMatch for the callback API.
+// Inline switch thresholds for the callback walk (singleRareWalk): the
+// same ~2.6% break-even singlePairDense encodes, but accumulated over
+// the bytes the scan has already covered instead of sampled windows, so
+// the walk never reads ahead of itself. Switch once the candidate count
+// carries the same evidence mass as the eager sampler (78 hits) while
+// still outpacing one candidate per singleSwitchSpan bytes.
+const (
+	singleSwitchMinCands = 78
+	singleSwitchSpan     = 38 // ~1/2.6%
+)
+
+// singleRareWalk is singleRareMatch for the callback API, with the lazy
+// density switch described at walkSingle: when the rare byte proves
+// locally common, hand the remainder of the input to the pair scan.
 func (tr *Trie) singleRareWalk(input []byte, fn WalkFn) {
 	p := tr.single
 	n := len(p)
 	o1, o2 := tr.singleO1, tr.singleO2
 	c1, c2 := p[o1], p[o2]
 	dp := tr.singleDP
+	skip := tr.singleSkip
+	prev := -1
+	cands := 0
 	for i := 0; i+n <= len(input); {
 		j := bytes.IndexByte(input[i+o1:], c1)
 		if j < 0 {
@@ -296,11 +386,20 @@ func (tr *Trie) singleRareWalk(input []byte, fn WalkFn) {
 		if pos+n > len(input) {
 			return
 		}
-		if input[pos+o2] == c2 && singleVerify(input, pos, p) {
+		cands++
+		if cands >= singleSwitchMinCands && cands*singleSwitchSpan > pos {
+			// Candidates are dense: the pair scan wins from here on.
+			// It resumes at this (unprocessed) candidate, so nothing
+			// is skipped or emitted twice.
+			tr.singlePairWalkFrom(input, pos, fn)
+			return
+		}
+		if input[pos+o2] == c2 && singleVerifyCarry(input, pos, prev, skip, p) {
 			if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
 				return
 			}
-			i = pos + tr.singleSkip
+			prev = pos
+			i = pos + skip
 		} else {
 			i = pos + 1
 		}
@@ -320,9 +419,11 @@ func (tr *Trie) singlePairMatch(input []byte, buf *matchBuf) {
 	ca := swarOnes * uint64(p[oa])
 	cb := swarOnes * uint64(p[ob])
 	dp := tr.singleDP
+	skip := tr.singleSkip
 
 	limit := len(input) - n // last valid start
 	next := 0               // next start allowed by the KMP period
+	prev := -1              // last confirmed match start, for the period carry
 	i := 0
 	// Two independent 8-byte lanes per iteration: the lanes share no
 	// data, so their load-xor-test chains overlap and the common no-hit
@@ -331,7 +432,9 @@ func (tr *Trie) singlePairMatch(input []byte, buf *matchBuf) {
 	// through a 16-byte reslice of provably constant length, so the
 	// compiler keeps one bounds check per slice and elides the rest;
 	// binary.LittleEndian keeps the byte order portable (it compiles
-	// to a plain load on little-endian targets).
+	// to a plain load on little-endian targets). The intersected
+	// swarZero masks can carry borrow false positives (see swarZero);
+	// singleVerifyCarry, not the mask, is the correctness boundary.
 	for ; i+ob+16 <= len(input); i += 16 {
 		wA := input[i+oa : i+oa+16]
 		wB := input[i+ob : i+ob+16]
@@ -350,9 +453,10 @@ func (tr *Trie) singlePairMatch(input []byte, buf *matchBuf) {
 			if pos < next || pos > limit {
 				continue
 			}
-			if singleVerify(input, pos, p) {
+			if singleVerifyCarry(input, pos, prev, skip, p) {
 				buf.raw = append(buf.raw, uint64(pos+n-1), dp)
-				next = pos + tr.singleSkip
+				prev = pos
+				next = pos + skip
 			}
 		}
 		for m1 != 0 {
@@ -361,22 +465,33 @@ func (tr *Trie) singlePairMatch(input []byte, buf *matchBuf) {
 			if pos < next || pos > limit {
 				continue
 			}
-			if singleVerify(input, pos, p) {
+			if singleVerifyCarry(input, pos, prev, skip, p) {
 				buf.raw = append(buf.raw, uint64(pos+n-1), dp)
-				next = pos + tr.singleSkip
+				prev = pos
+				next = pos + skip
 			}
 		}
 	}
 	for pos := max(i, next); pos <= limit; pos++ {
-		if input[pos+oa] == p[oa] && input[pos+ob] == p[ob] && singleVerify(input, pos, p) {
+		if input[pos+oa] == p[oa] && input[pos+ob] == p[ob] &&
+			singleVerifyCarry(input, pos, prev, skip, p) {
 			buf.raw = append(buf.raw, uint64(pos+n-1), dp)
-			pos += tr.singleSkip - 1 // the loop increment adds the 1 back
+			prev = pos
+			pos += skip - 1 // the loop increment adds the 1 back
 		}
 	}
 }
 
 // singlePairWalk is singlePairMatch for the callback API.
 func (tr *Trie) singlePairWalk(input []byte, fn WalkFn) {
+	tr.singlePairWalkFrom(input, 0, fn)
+}
+
+// singlePairWalkFrom is singlePairWalk starting at candidate position
+// start, so singleRareWalk's mid-scan density switch can hand off the
+// unscanned remainder. Candidates before start were already handled (or
+// proven impossible) by the caller.
+func (tr *Trie) singlePairWalkFrom(input []byte, start int, fn WalkFn) {
 	p := tr.single
 	n := len(p)
 	oa, ob := tr.singleO1, tr.singleO2
@@ -386,10 +501,12 @@ func (tr *Trie) singlePairWalk(input []byte, fn WalkFn) {
 	ca := swarOnes * uint64(p[oa])
 	cb := swarOnes * uint64(p[ob])
 	dp := tr.singleDP
+	skip := tr.singleSkip
 
 	limit := len(input) - n
-	next := 0
-	i := 0
+	next := start
+	prev := -1
+	i := start
 	// Same two-lane structure as singlePairMatch.
 	for ; i+ob+16 <= len(input); i += 16 {
 		wA := input[i+oa : i+oa+16]
@@ -409,11 +526,12 @@ func (tr *Trie) singlePairWalk(input []byte, fn WalkFn) {
 			if pos < next || pos > limit {
 				continue
 			}
-			if singleVerify(input, pos, p) {
+			if singleVerifyCarry(input, pos, prev, skip, p) {
 				if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
 					return
 				}
-				next = pos + tr.singleSkip
+				prev = pos
+				next = pos + skip
 			}
 		}
 		for m1 != 0 {
@@ -422,26 +540,39 @@ func (tr *Trie) singlePairWalk(input []byte, fn WalkFn) {
 			if pos < next || pos > limit {
 				continue
 			}
-			if singleVerify(input, pos, p) {
+			if singleVerifyCarry(input, pos, prev, skip, p) {
 				if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
 					return
 				}
-				next = pos + tr.singleSkip
+				prev = pos
+				next = pos + skip
 			}
 		}
 	}
 	for pos := max(i, next); pos <= limit; pos++ {
-		if input[pos+oa] == p[oa] && input[pos+ob] == p[ob] && singleVerify(input, pos, p) {
+		if input[pos+oa] == p[oa] && input[pos+ob] == p[ob] &&
+			singleVerifyCarry(input, pos, prev, skip, p) {
 			if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
 				return
 			}
-			pos += tr.singleSkip - 1
+			prev = pos
+			pos += skip - 1
 		}
 	}
 }
 
-// swarZero returns a mask with bit 7 of each byte set iff that byte of w
-// is zero.
+// swarZero returns a mask with bit 7 of each byte set for every zero
+// byte of w. The mask is a superset, not exact: the subtraction borrows
+// across lanes, so a 0x01 lane sitting above a zero lane (or above a
+// chain of 0x01 lanes reaching one) is falsely flagged — a borrow can
+// only start at a true zero (v-1 underflows only for v == 0), and lanes
+// >= 0x02 either absorb it or have bit 7 masked off by &^ w. Every true
+// zero lane is always flagged, so there are no false negatives, and the
+// lowest set bit is always a true zero. The pair scans intersect two of
+// these masks as a candidate *filter*: a stray lane costs one
+// singleVerifyCarry call that exits on its first word, cheaper than
+// paying for an exact per-lane mask on the no-hit fast path that
+// dominates the scan.
 func swarZero(w uint64) uint64 {
 	return (w - swarOnes) &^ w & swarHighs
 }

--- a/single.go
+++ b/single.go
@@ -1,0 +1,447 @@
+package ahocorasick
+
+// Single-pattern fast path. A one-pattern trie needs no automaton: the
+// scan entry points dispatch to the substring searchers here, built on
+// the two fastest primitives available in pure Go on this hot path:
+//
+//   - rare-byte search (sparse inputs): vectorized bytes.IndexByte over
+//     the pattern's rarest byte generates candidate starts; a one-byte
+//     probe of the second-rarest byte rejects almost all false
+//     candidates before the full comparison. Runs near memory bandwidth
+//     between candidates but pays a call-and-restart cost per candidate.
+//
+//   - SWAR pair search (dense inputs): a word scan tests the two rarest
+//     bytes at their pattern offsets simultaneously, eight candidate
+//     starts per iteration, with no per-candidate restart cost.
+//     Throughput is flat (~3GB/s) regardless of candidate density.
+//
+// Each scan samples the rare byte's density and picks: rare-byte wins
+// when candidates are sparse, the pair scan when the "rare" byte is
+// locally common (e.g. prose, where every pattern byte is a frequent
+// letter).
+//
+// bytes.Index is deliberately not used: on arm64 it generates candidates
+// from the first byte only, so a common-first-byte needle over prose
+// degrades it to ~2GB/s.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math/bits"
+)
+
+// byteRank estimates how common each byte value is in text-like corpora
+// (higher = more common). Only the relative order matters: the searchers
+// pick the pattern's two lowest-ranked bytes as candidate filters. A
+// coarse heuristic in the spirit of the frequency tables behind
+// memchr/memmem prefilters.
+var byteRank = func() (r [256]uint8) {
+	for i := range r {
+		r[i] = 50 // binary/control bytes: rare
+	}
+	for b := 0x80; b <= 0xBF; b++ {
+		r[b] = 100 // UTF-8 continuation bytes
+	}
+	for b := 0xC0; b <= 0xDF; b++ {
+		r[b] = 95 // UTF-8 lead bytes (Latin scripts)
+	}
+	for b := '0'; b <= '9'; b++ {
+		r[b] = 80
+	}
+	for b := 'A'; b <= 'Z'; b++ {
+		r[b] = 85
+	}
+	for _, c := range []byte(`.,;:'"-()`) {
+		r[c] = 90
+	}
+	for _, c := range []byte(" \n\r\t") {
+		r[c] = 250
+	}
+	// Descending frequency ladder for lowercase letters.
+	for i, c := range []byte("etaoinsrhldcumfgpwybvkxjqz") {
+		r[c] = 245 - uint8(i)*5
+	}
+	return
+}()
+
+// buildSinglePattern detects the one-pattern trie shape and extracts its
+// pattern from the transition table, enabling the fast scan paths
+// (matchSingle, walkSingle). Derived like the other acceleration tables:
+// it reads only failTrans/dict/dictLink/dictPat, so Build and Decode both
+// reach the same result without any wire-format change.
+//
+// A single pattern of length n compiles to exactly n+2 states (nil, root,
+// one chain state per byte) numbered sequentially by the BFS renumbering,
+// with one emitting state (the chain end) and no dictLink entries. The
+// pattern bytes are recovered by walking the chain: only the true child
+// edge of state s can reach state s+1, because every other entry in the
+// row was copied from a strictly shallower fail state whose targets are
+// all shallower than s+1.
+//
+// Must run after buildDictPat (reads maxLen and dictPat).
+func (tr *Trie) buildSinglePattern() {
+	tr.single = nil
+	n := int(tr.maxLen)
+	if n < 1 || len(tr.failTrans) != n+2 {
+		return
+	}
+	final := uint32(n) + 1
+	for s := range tr.dict {
+		if tr.dict[s] != 0 && uint32(s) != final {
+			return
+		}
+		if tr.dictLink[s] != nilState {
+			return
+		}
+	}
+	if tr.dict[final] != uint32(n) {
+		return
+	}
+	pat := make([]byte, 0, n)
+	for s := rootState; s <= uint32(n); s++ {
+		row := &tr.failTrans[s]
+		found := -1
+		for b := range 256 {
+			if row[b]&stateMask == s+1 {
+				if found >= 0 {
+					return
+				}
+				found = b
+			}
+		}
+		if found < 0 {
+			return
+		}
+		pat = append(pat, byte(found))
+	}
+	tr.single = pat
+	tr.singleDP = tr.dictPat[final]
+
+	// KMP prefix function: the minimal distance between overlapping
+	// occurrence starts is the period n - lps[n-1]. Advancing by it
+	// after each hit finds every overlapping occurrence while keeping
+	// the rescan linear on periodic patterns.
+	lps := make([]int, n)
+	for i, k := 1, 0; i < n; i++ {
+		for k > 0 && pat[i] != pat[k] {
+			k = lps[k-1]
+		}
+		if pat[i] == pat[k] {
+			k++
+		}
+		lps[i] = k
+	}
+	tr.singleSkip = n - lps[n-1]
+
+	// Candidate filter offsets: the two lowest-ranked (rarest) pattern
+	// bytes at distinct offsets. Rank ties prefer the offset farther
+	// from the first pick — adjacent text bytes correlate (digraphs),
+	// so separation buys discrimination.
+	o1 := 0
+	for k := 1; k < n; k++ {
+		if byteRank[pat[k]] < byteRank[pat[o1]] {
+			o1 = k
+		}
+	}
+	o2 := o1
+	for k := range n {
+		if k == o1 {
+			continue
+		}
+		if o2 == o1 || byteRank[pat[k]] < byteRank[pat[o2]] ||
+			(byteRank[pat[k]] == byteRank[pat[o2]] && absInt(k-o1) > absInt(o2-o1)) {
+			o2 = k
+		}
+	}
+	tr.singleO1, tr.singleO2 = o1, o2
+}
+
+func absInt(x int) int {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// singleVerify reports whether the pattern p occurs at input[pos:]. The
+// caller guarantees pos+len(p) <= len(input). Word-wide compares (with an
+// overlapped tail load) avoid bytes.Equal's call overhead on the
+// candidate-verification path.
+func singleVerify(input []byte, pos int, p []byte) bool {
+	n := len(p)
+	if n < 8 {
+		for k := 0; k < n; k++ {
+			if input[pos+k] != p[k] {
+				return false
+			}
+		}
+		return true
+	}
+	k := 0
+	for ; k+8 <= n; k += 8 {
+		if binary.LittleEndian.Uint64(input[pos+k:]) != binary.LittleEndian.Uint64(p[k:]) {
+			return false
+		}
+	}
+	// Overlapped final word re-compares up to 7 already-verified bytes.
+	return k == n ||
+		binary.LittleEndian.Uint64(input[pos+n-8:]) == binary.LittleEndian.Uint64(p[n-8:])
+}
+
+// singlePairDense reports whether rare-byte candidate density is high
+// enough that the flat-throughput SWAR pair scan beats IndexByte
+// candidate generation. Break-even (measured, Neoverse V1): rare-byte
+// search costs ~20ns/KB of scan plus ~13ns per candidate; the pair scan
+// ~345ns/KB flat — so rare-byte loses above ~26 candidates per KB (~2.6%
+// density). Three 1KB windows (head, middle, tail) sample the density;
+// below 8KB the stakes are too small to pay for sampling.
+func (tr *Trie) singlePairDense(input []byte) bool {
+	if len(input) < 8<<10 {
+		return false
+	}
+	c := tr.single[tr.singleO1 : tr.singleO1+1]
+	n := len(input)
+	k := bytes.Count(input[:1024], c)
+	k += bytes.Count(input[n/2:n/2+1024], c)
+	k += bytes.Count(input[n-1024:], c)
+	return k >= 78 // ~2.6% of the 3KB sampled
+}
+
+// matchSingle appends every (overlapping) occurrence of the one-pattern
+// trie's pattern. Emission order (by end position) matches the automaton
+// paths.
+func (tr *Trie) matchSingle(input []byte, buf *matchBuf) {
+	if len(tr.single) == 1 {
+		c := tr.single[0]
+		dp := tr.singleDP
+		for i := 0; ; i++ {
+			j := bytes.IndexByte(input[i:], c)
+			if j < 0 {
+				return
+			}
+			i += j
+			buf.raw = append(buf.raw, uint64(i), dp)
+		}
+	}
+	if tr.singlePairDense(input) {
+		tr.singlePairMatch(input, buf)
+		return
+	}
+	tr.singleRareMatch(input, buf)
+}
+
+// walkSingle is matchSingle for the callback API.
+func (tr *Trie) walkSingle(input []byte, fn WalkFn) {
+	if len(tr.single) == 1 {
+		c := tr.single[0]
+		dp := tr.singleDP
+		for i := 0; ; i++ {
+			j := bytes.IndexByte(input[i:], c)
+			if j < 0 {
+				return
+			}
+			i += j
+			if !fn(uint32(i), uint32(dp), uint32(dp>>32)) {
+				return
+			}
+		}
+	}
+	if tr.singlePairDense(input) {
+		tr.singlePairWalk(input, fn)
+		return
+	}
+	tr.singleRareWalk(input, fn)
+}
+
+// singleRareMatch: IndexByte over the rarest pattern byte generates
+// candidates; a second-byte probe rejects false ones before the full
+// comparison. Requires len(tr.single) >= 2.
+func (tr *Trie) singleRareMatch(input []byte, buf *matchBuf) {
+	p := tr.single
+	n := len(p)
+	o1, o2 := tr.singleO1, tr.singleO2
+	c1, c2 := p[o1], p[o2]
+	dp := tr.singleDP
+	for i := 0; i+n <= len(input); {
+		j := bytes.IndexByte(input[i+o1:], c1)
+		if j < 0 {
+			return
+		}
+		pos := i + j // the found byte sits at candidate offset o1
+		if pos+n > len(input) {
+			return
+		}
+		if input[pos+o2] == c2 && singleVerify(input, pos, p) {
+			buf.raw = append(buf.raw, uint64(pos+n-1), dp)
+			i = pos + tr.singleSkip
+		} else {
+			i = pos + 1
+		}
+	}
+}
+
+// singleRareWalk is singleRareMatch for the callback API.
+func (tr *Trie) singleRareWalk(input []byte, fn WalkFn) {
+	p := tr.single
+	n := len(p)
+	o1, o2 := tr.singleO1, tr.singleO2
+	c1, c2 := p[o1], p[o2]
+	dp := tr.singleDP
+	for i := 0; i+n <= len(input); {
+		j := bytes.IndexByte(input[i+o1:], c1)
+		if j < 0 {
+			return
+		}
+		pos := i + j
+		if pos+n > len(input) {
+			return
+		}
+		if input[pos+o2] == c2 && singleVerify(input, pos, p) {
+			if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
+				return
+			}
+			i = pos + tr.singleSkip
+		} else {
+			i = pos + 1
+		}
+	}
+}
+
+// singlePairMatch: SWAR scan testing the two rarest pattern bytes at
+// their offsets simultaneously, eight candidate starts per iteration.
+// Requires len(tr.single) >= 2.
+func (tr *Trie) singlePairMatch(input []byte, buf *matchBuf) {
+	p := tr.single
+	n := len(p)
+	oa, ob := tr.singleO1, tr.singleO2
+	if oa > ob {
+		oa, ob = ob, oa
+	}
+	ca := swarOnes * uint64(p[oa])
+	cb := swarOnes * uint64(p[ob])
+	dp := tr.singleDP
+
+	limit := len(input) - n // last valid start
+	next := 0               // next start allowed by the KMP period
+	i := 0
+	// Two independent 8-byte lanes per iteration: the lanes share no
+	// data, so their load-xor-test chains overlap and the common no-hit
+	// case takes one branch per 16 bytes. Lane 0 hits precede lane 1
+	// hits, so emission order stays increasing. Each lane pair loads
+	// through a 16-byte reslice of provably constant length, so the
+	// compiler keeps one bounds check per slice and elides the rest;
+	// binary.LittleEndian keeps the byte order portable (it compiles
+	// to a plain load on little-endian targets).
+	for ; i+ob+16 <= len(input); i += 16 {
+		wA := input[i+oa : i+oa+16]
+		wB := input[i+ob : i+ob+16]
+		wa0 := binary.LittleEndian.Uint64(wA)
+		wb0 := binary.LittleEndian.Uint64(wB)
+		wa1 := binary.LittleEndian.Uint64(wA[8:])
+		wb1 := binary.LittleEndian.Uint64(wB[8:])
+		m0 := swarZero(wa0^ca) & swarZero(wb0^cb)
+		m1 := swarZero(wa1^ca) & swarZero(wb1^cb)
+		if m0|m1 == 0 {
+			continue
+		}
+		for m0 != 0 {
+			pos := i + bits.TrailingZeros64(m0)>>3
+			m0 &= m0 - 1
+			if pos < next || pos > limit {
+				continue
+			}
+			if singleVerify(input, pos, p) {
+				buf.raw = append(buf.raw, uint64(pos+n-1), dp)
+				next = pos + tr.singleSkip
+			}
+		}
+		for m1 != 0 {
+			pos := i + 8 + bits.TrailingZeros64(m1)>>3
+			m1 &= m1 - 1
+			if pos < next || pos > limit {
+				continue
+			}
+			if singleVerify(input, pos, p) {
+				buf.raw = append(buf.raw, uint64(pos+n-1), dp)
+				next = pos + tr.singleSkip
+			}
+		}
+	}
+	for pos := max(i, next); pos <= limit; pos++ {
+		if input[pos+oa] == p[oa] && input[pos+ob] == p[ob] && singleVerify(input, pos, p) {
+			buf.raw = append(buf.raw, uint64(pos+n-1), dp)
+			pos += tr.singleSkip - 1 // the loop increment adds the 1 back
+		}
+	}
+}
+
+// singlePairWalk is singlePairMatch for the callback API.
+func (tr *Trie) singlePairWalk(input []byte, fn WalkFn) {
+	p := tr.single
+	n := len(p)
+	oa, ob := tr.singleO1, tr.singleO2
+	if oa > ob {
+		oa, ob = ob, oa
+	}
+	ca := swarOnes * uint64(p[oa])
+	cb := swarOnes * uint64(p[ob])
+	dp := tr.singleDP
+
+	limit := len(input) - n
+	next := 0
+	i := 0
+	// Same two-lane structure as singlePairMatch.
+	for ; i+ob+16 <= len(input); i += 16 {
+		wA := input[i+oa : i+oa+16]
+		wB := input[i+ob : i+ob+16]
+		wa0 := binary.LittleEndian.Uint64(wA)
+		wb0 := binary.LittleEndian.Uint64(wB)
+		wa1 := binary.LittleEndian.Uint64(wA[8:])
+		wb1 := binary.LittleEndian.Uint64(wB[8:])
+		m0 := swarZero(wa0^ca) & swarZero(wb0^cb)
+		m1 := swarZero(wa1^ca) & swarZero(wb1^cb)
+		if m0|m1 == 0 {
+			continue
+		}
+		for m0 != 0 {
+			pos := i + bits.TrailingZeros64(m0)>>3
+			m0 &= m0 - 1
+			if pos < next || pos > limit {
+				continue
+			}
+			if singleVerify(input, pos, p) {
+				if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
+					return
+				}
+				next = pos + tr.singleSkip
+			}
+		}
+		for m1 != 0 {
+			pos := i + 8 + bits.TrailingZeros64(m1)>>3
+			m1 &= m1 - 1
+			if pos < next || pos > limit {
+				continue
+			}
+			if singleVerify(input, pos, p) {
+				if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
+					return
+				}
+				next = pos + tr.singleSkip
+			}
+		}
+	}
+	for pos := max(i, next); pos <= limit; pos++ {
+		if input[pos+oa] == p[oa] && input[pos+ob] == p[ob] && singleVerify(input, pos, p) {
+			if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
+				return
+			}
+			pos += tr.singleSkip - 1
+		}
+	}
+}
+
+// swarZero returns a mask with bit 7 of each byte set iff that byte of w
+// is zero.
+func swarZero(w uint64) uint64 {
+	return (w - swarOnes) &^ w & swarHighs
+}

--- a/singlepattern_test.go
+++ b/singlepattern_test.go
@@ -244,3 +244,137 @@ func TestSingleWalkStrategiesStop(t *testing.T) {
 		}
 	}
 }
+
+// TestSinglePatternRejectsNoncanonicalTable corrupts individual
+// transition entries of canonical single-pattern tables and asserts the
+// detector turns the fast path off: the shape checks (state count, one
+// output, one chain edge per state) can all pass while a non-chain
+// entry still disagrees with the KMP automaton the pattern implies, and
+// scanning with the recovered pattern would then diverge from the
+// generic paths. Decode accepts any in-range table, so such tables are
+// reachable from corrupt or hostile streams.
+func TestSinglePatternRejectsNoncanonicalTable(t *testing.T) {
+	cases := []struct {
+		name    string
+		pattern string
+		state   uint32 // state whose row to corrupt
+		b       byte   // row entry to corrupt
+		to      uint32 // new target (plain state id)
+	}{
+		// The final state must re-enter the chain on the pattern byte
+		// (overlapping occurrence); dropping to the root makes the
+		// generic path emit once on "aa" where the recovered-pattern
+		// path emits twice.
+		{"final drops to root", "a", 2, 'a', rootState},
+		// A root non-pattern byte must self-loop, not jump into the
+		// chain.
+		{"root leaves on foreign byte", "ab", rootState, 'z', 3},
+		// A mid-chain non-chain byte must copy the fail state's row,
+		// not self-loop.
+		{"mid-chain wrong fallback", "abab", 3, 'z', 3},
+		// A periodic pattern's chain state must fall back into the
+		// chain on its period byte, not to the root.
+		{"periodic fallback to root", "abab", 4, 'a', rootState},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := NewTrieBuilder().AddString(tc.pattern).Build()
+			if tr.single == nil {
+				t.Fatal("canonical table not detected as single")
+			}
+			if old := tr.failTrans[tc.state][tc.b] & stateMask; old == tc.to {
+				t.Fatalf("corruption is a no-op: entry already %d", tc.to)
+			}
+			tr.failTrans[tc.state][tc.b] = tc.to
+			tr.addOutputFlags() // re-derive flags for the new target
+			tr.buildSinglePattern()
+			if tr.single != nil {
+				t.Fatalf("noncanonical table still detected: single = %q", tr.single)
+			}
+		})
+	}
+}
+
+// TestSinglePatternPeriodicCarry cross-checks the KMP-period carry
+// (singleVerifyCarry) in all searchers against the naive reference on
+// inputs built to stress it: long runs of overlapping occurrences
+// (where the carry verifies only the tail bytes per match), runs broken
+// by a corrupted byte at every alignment near a match boundary (where a
+// carry-qualified candidate must still fail), and occurrences at
+// non-period distances (where the carry must not apply).
+func TestSinglePatternPeriodicCarry(t *testing.T) {
+	patterns := []string{
+		"aa",                     // period 1, byte-loop verify
+		strings.Repeat("a", 10),  // period 1, word-loop verify
+		strings.Repeat("ab", 6),  // period 2
+		"aabaa",                  // period 3, bordered
+		strings.Repeat("abz", 8), // period 3, longer
+		"aaaaaaab",               // period n (no overlap savings)
+	}
+	for _, pat := range patterns {
+		tr := NewTrieBuilder().AddString(pat).Build()
+		if tr.single == nil {
+			t.Fatalf("%q: single not detected", pat)
+		}
+		var inputs [][]byte
+		// Pure periodic runs: maximal overlap, matches every period.
+		inputs = append(inputs,
+			bytes.Repeat([]byte(pat), 40),
+			bytes.Repeat([]byte(pat[:tr.singleSkip]), 40*len(pat)/tr.singleSkip),
+		)
+		// Runs broken at every offset around the second occurrence: the
+		// carry proves the prefix, so the corrupted byte must be caught
+		// by the tail compare.
+		base := bytes.Repeat([]byte(pat), 40)
+		for off := len(pat); off < 3*len(pat) && off < len(base); off++ {
+			in := append([]byte(nil), base...)
+			in[off] ^= 0xFF
+			inputs = append(inputs, in)
+		}
+		// Occurrences at a non-period gap: carry must not apply.
+		gap := append([]byte(pat), 'q', 'w')
+		gap = append(gap, pat...)
+		inputs = append(inputs, gap)
+
+		for k, input := range inputs {
+			want := naiveMatch([]string{pat}, input)
+			var bufA, bufB matchBuf
+			tr.singleRareMatch(input, &bufA)
+			if d := diffTriples(rawTriples(bufA.raw), want); d != -1 {
+				t.Fatalf("%q input %d: rare-byte diverges at %d", pat, k, d)
+			}
+			tr.singlePairMatch(input, &bufB)
+			if d := diffTriples(rawTriples(bufB.raw), want); d != -1 {
+				t.Fatalf("%q input %d: pair scan diverges at %d", pat, k, d)
+			}
+			if d := diffTriples(tr.triplesFromWalk(input), want); d != -1 {
+				t.Fatalf("%q input %d: walk diverges at %d", pat, k, d)
+			}
+		}
+	}
+}
+
+// TestSingleWalkDensitySwitch drives walkSingle over inputs dense
+// enough to trip the inline rare-to-pair switch and verifies the
+// handoff loses and duplicates nothing across the boundary.
+func TestSingleWalkDensitySwitch(t *testing.T) {
+	for _, pat := range []string{"ab", "aa", "abab", "aabaa"} {
+		tr := NewTrieBuilder().AddString(pat).Build()
+		if tr.single == nil {
+			t.Fatalf("%q: single not detected", pat)
+		}
+		denseTail := bytes.Repeat([]byte("qw"), 4096)
+		denseTail = append(denseTail, bytes.Repeat([]byte(pat), 4096/len(pat))...)
+		inputs := [][]byte{
+			bytes.Repeat([]byte(pat), 8192/len(pat)), // dense from byte 0
+			bytes.Repeat([]byte(pat[:1]), 16384),     // rare byte everywhere
+			denseTail,                                // sparse head, dense tail
+		}
+		for k, input := range inputs {
+			want := naiveMatch([]string{pat}, input)
+			if d := diffTriples(tr.triplesFromWalk(input), want); d != -1 {
+				t.Fatalf("%q input %d: walk diverges at %d", pat, k, d)
+			}
+		}
+	}
+}

--- a/singlepattern_test.go
+++ b/singlepattern_test.go
@@ -1,0 +1,246 @@
+package ahocorasick
+
+// Tests for the single-pattern fast path (buildSinglePattern, matchSingle,
+// walkSingle): detection of the one-pattern trie shape, byte-for-byte
+// agreement with the generic automaton paths and the naive reference, KMP
+// period handling on periodic patterns, Walk termination, and survival of
+// the Encode/Decode roundtrip.
+
+import (
+	"bytes"
+	"math/rand"
+	"strings"
+	"testing"
+)
+
+func TestSinglePatternDetection(t *testing.T) {
+	cases := []struct {
+		name     string
+		patterns []string
+		want     string // "" => single must be nil
+	}{
+		{"one word", []string{"Hedvig"}, "Hedvig"},
+		{"one byte", []string{"x"}, "x"},
+		{"duplicate adds collapse", []string{"abc", "abc"}, "abc"},
+		{"periodic", []string{"abab"}, "abab"},
+		{"self-overlap run", []string{"aa"}, "aa"},
+		{"utf8 bytes", []string{"æøå"}, "æøå"},
+		{"two patterns", []string{"ab", "cd"}, ""},
+		{"prefix pair", []string{"ab", "abc"}, ""},
+		{"suffix pair", []string{"bc", "abc"}, ""},
+		{"long", []string{strings.Repeat("abz", 40)}, strings.Repeat("abz", 40)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tr := NewTrieBuilder().AddStrings(tc.patterns).Build()
+			if tc.want == "" {
+				if tr.single != nil {
+					t.Fatalf("single = %q, want nil", tr.single)
+				}
+				return
+			}
+			if string(tr.single) != tc.want {
+				t.Fatalf("single = %q, want %q", tr.single, tc.want)
+			}
+			if got, want := uint32(tr.singleDP), uint32(len(tc.want)); got != want {
+				t.Fatalf("singleDP length = %d, want %d", got, want)
+			}
+		})
+	}
+}
+
+func TestSinglePatternSkipIsKMPPeriod(t *testing.T) {
+	cases := []struct {
+		pattern string
+		skip    int
+	}{
+		{"a", 1},
+		{"aa", 1},
+		{"ab", 2},
+		{"aba", 2},
+		{"abab", 2},
+		{"aabaa", 3},
+		{"Hedvig", 6},
+	}
+	for _, tc := range cases {
+		tr := NewTrieBuilder().AddString(tc.pattern).Build()
+		if tr.singleSkip != tc.skip {
+			t.Errorf("%q: singleSkip = %d, want %d", tc.pattern, tr.singleSkip, tc.skip)
+		}
+	}
+}
+
+// singleInputs exercises: no match, match at 0, match at end, overlapping
+// periodic matches, inputs shorter than the pattern, and empty input.
+func singleInputs(pattern string) [][]byte {
+	rep := bytes.Repeat([]byte(pattern), 5)
+	return [][]byte{
+		nil,
+		[]byte(""),
+		[]byte(pattern),
+		[]byte(pattern[:len(pattern)-1]),
+		[]byte(pattern + " tail"),
+		[]byte("head " + pattern),
+		[]byte("no occurrences here at all"),
+		rep,
+		bytes.Repeat(append([]byte(pattern), ' '), 3),
+		append(bytes.Repeat([]byte{pattern[0]}, 20), pattern...),
+	}
+}
+
+func TestSinglePatternMatchesReference(t *testing.T) {
+	for _, pattern := range []string{"a", "aa", "ab", "aba", "abab", "aabaa", "Hedvig", "æøå"} {
+		t.Run(pattern, func(t *testing.T) {
+			tr := NewTrieBuilder().AddString(pattern).Build()
+			if tr.single == nil {
+				t.Fatal("single not detected")
+			}
+			for _, input := range singleInputs(pattern) {
+				want := naiveMatch([]string{pattern}, input)
+
+				ms := tr.Match(input)
+				if d := diffTriples(triplesFromMatches(ms), want); d != -1 {
+					t.Fatalf("Match(%q) diverges from reference at %d", input, d)
+				}
+				tr.ReleaseMatches(ms)
+
+				if d := diffTriples(tr.triplesFromWalk(input), want); d != -1 {
+					t.Fatalf("Walk(%q) diverges from reference at %d", input, d)
+				}
+
+				// The generic automaton path must agree too: disable
+				// the fast path and rerun (white-box).
+				save := tr.single
+				tr.single = nil
+				ms = tr.Match(input)
+				if d := diffTriples(triplesFromMatches(ms), want); d != -1 {
+					t.Fatalf("generic Match(%q) diverges from reference at %d", input, d)
+				}
+				tr.ReleaseMatches(ms)
+				tr.single = save
+			}
+		})
+	}
+}
+
+func TestSinglePatternMatchFirst(t *testing.T) {
+	tr := NewTrieBuilder().AddString("needle").Build()
+	input := []byte("hay needle hay needle")
+	m := tr.MatchFirst(input)
+	if m == nil || m.Pos() != 4 || m.MatchString() != "needle" {
+		t.Fatalf("MatchFirst = %v, want needle at 4", m)
+	}
+	if m := tr.MatchFirst([]byte("no hit")); m != nil {
+		t.Fatalf("MatchFirst on miss = %v, want nil", m)
+	}
+}
+
+func TestSinglePatternWalkStops(t *testing.T) {
+	tr := NewTrieBuilder().AddString("aa").Build()
+	calls := 0
+	tr.Walk([]byte("aaaa"), func(end, n, pattern uint32) bool {
+		calls++
+		return false
+	})
+	if calls != 1 {
+		t.Fatalf("Walk called callback %d times after false, want 1", calls)
+	}
+}
+
+func TestSinglePatternDecodeRoundtrip(t *testing.T) {
+	tr := NewTrieBuilder().AddString("abab").Build()
+	var blob bytes.Buffer
+	if err := Encode(&blob, tr); err != nil {
+		t.Fatal(err)
+	}
+	dec, err := Decode(&blob)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(dec.single) != "abab" {
+		t.Fatalf("decoded single = %q, want %q", dec.single, "abab")
+	}
+	if dec.singleSkip != tr.singleSkip {
+		t.Fatalf("decoded singleSkip = %d, want %d", dec.singleSkip, tr.singleSkip)
+	}
+	input := []byte("xxababab yy abab")
+	want := naiveMatch([]string{"abab"}, input)
+	ms := dec.Match(input)
+	if d := diffTriples(triplesFromMatches(ms), want); d != -1 {
+		t.Fatalf("decoded Match diverges from reference at %d", d)
+	}
+	dec.ReleaseMatches(ms)
+}
+
+// rawTriples converts matchBuf raw pairs to reference triples.
+func rawTriples(raw []uint64) [][3]uint32 {
+	var out [][3]uint32
+	for k := 0; k+1 < len(raw); k += 2 {
+		end, dp := raw[k], raw[k+1]
+		l := uint32(dp)
+		out = append(out, [3]uint32{uint32(end) - l + 1, uint32(dp >> 32), l})
+	}
+	return out
+}
+
+// TestSingleStrategiesDifferential cross-checks both single-pattern
+// search strategies (rare-byte IndexByte and SWAR pair) directly against
+// the naive reference, on inputs dense and large enough to exercise the
+// pair scan's word loop, its KMP-period suppression, and its scalar tail.
+func TestSingleStrategiesDifferential(t *testing.T) {
+	rng := rand.New(rand.NewSource(99))
+	patterns := []string{"ab", "aa", "aba", "abab", "aabaa", "xyzzy", "Hedvig"}
+	alphabets := []string{"ab", "abcxyz", "abcdefghijklmnopqrstuvwxyz "}
+	sizes := []int{0, 1, 7, 63, 100, 1000, 8192, 9001, 32768}
+
+	for _, pat := range patterns {
+		tr := NewTrieBuilder().AddString(pat).Build()
+		if tr.single == nil {
+			t.Fatalf("%q: single not detected", pat)
+		}
+		for _, alpha := range alphabets {
+			for _, size := range sizes {
+				input := make([]byte, size)
+				for i := range input {
+					input[i] = alpha[rng.Intn(len(alpha))]
+				}
+				// Plant some real occurrences.
+				for k := 0; k < size/64; k++ {
+					pos := rng.Intn(size)
+					copy(input[pos:], pat)
+				}
+				want := naiveMatch([]string{pat}, input)
+
+				var bufA, bufB matchBuf
+				tr.singleRareMatch(input, &bufA)
+				if d := diffTriples(rawTriples(bufA.raw), want); d != -1 {
+					t.Fatalf("%q/%s/%d: rare-byte diverges at %d", pat, alpha, size, d)
+				}
+				tr.singlePairMatch(input, &bufB)
+				if d := diffTriples(rawTriples(bufB.raw), want); d != -1 {
+					t.Fatalf("%q/%s/%d: pair scan diverges at %d", pat, alpha, size, d)
+				}
+			}
+		}
+	}
+}
+
+// TestSingleWalkStrategiesStop verifies early termination in both
+// strategy walk variants on dense input.
+func TestSingleWalkStrategiesStop(t *testing.T) {
+	tr := NewTrieBuilder().AddString("ab").Build()
+	input := bytes.Repeat([]byte("ab"), 8192) // 16KB, dense
+	for name, walk := range map[string]func([]byte, WalkFn){
+		"rare": tr.singleRareWalk,
+		"pair": tr.singlePairWalk,
+	} {
+		calls := 0
+		walk(input, func(end, n, pattern uint32) bool {
+			calls++
+			return calls < 3
+		})
+		if calls != 3 {
+			t.Errorf("%s: %d calls after stop at 3", name, calls)
+		}
+	}
+}

--- a/stream.go
+++ b/stream.go
@@ -258,5 +258,6 @@ func (dec *decoder) decode(maxStates int) (*Trie, error) {
 		}
 	}
 	trie.setStopEntry()
+	trie.buildSinglePattern()
 	return trie, nil
 }

--- a/trie.go
+++ b/trie.go
@@ -91,6 +91,23 @@ type Trie struct {
 	classOf    [256]uint8
 	classShift uint32
 
+	// single holds the pattern of a one-pattern trie; nil otherwise.
+	// A single pattern needs no automaton at all: the scan entry points
+	// use vectorized substring search (see single.go) instead of walking
+	// transition rows, which also skips every sampling/dispatch gate.
+	// singleDP is the packed (pattern id, length) pair of the emitting
+	// state, and singleSkip the pattern's KMP period (n - lps):
+	// consecutive occurrence starts differ by at least the period, so
+	// advancing by it after each hit finds every overlapping occurrence
+	// while keeping the rescan linear on periodic patterns. singleO1
+	// and singleO2 are the offsets of the two rarest pattern bytes (by
+	// static frequency rank), used as candidate filters.
+	single     []byte
+	singleDP   uint64
+	singleSkip int
+	singleO1   int
+	singleO2   int
+
 	bufPool sync.Pool // Pool of *matchBuf
 }
 
@@ -547,6 +564,10 @@ type WalkFn func(end, n, pattern uint32) bool
 // Walk runs the algorithm on a given output, calling the supplied callback function on every
 // match. The algorithm will terminate if the callback function returns false.
 func (tr *Trie) Walk(input []byte, fn WalkFn) {
+	if tr.single != nil {
+		tr.walkSingle(input, fn)
+		return
+	}
 	if tr.failTrans16 != nil {
 		if len(tr.rootStopBytes) == 1 {
 			tr.walkStopByte16(input, fn)
@@ -808,6 +829,12 @@ const parallelSparseMin = 128 << 10
 // sample so a process that can never parallelize (maxProcs 1) does not
 // pay for sampling it cannot act on.
 func (tr *Trie) parallelWorkers(input []byte, maxProcs int) int {
+	// A one-pattern trie scans with vectorized substring search at
+	// memory bandwidth (see single.go); worker goroutines and the
+	// density gates below cannot beat it.
+	if tr.single != nil {
+		return 0
+	}
 	if len(input) < parallelMin {
 		return 0
 	}
@@ -1148,6 +1175,10 @@ func (tr *Trie) rootLively(input []byte) bool {
 
 // matchSeq scans input sequentially into buf.
 func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
+	if tr.single != nil {
+		tr.matchSingle(input, buf)
+		return
+	}
 	if tr.failTrans16 != nil && len(tr.rootStopBytes) == 1 {
 		// Dual-scan only when the maxLen-1 bytes lane B re-scans are a
 		// small fraction of a half, and the input's excursion shape


### PR DESCRIPTION
A one-pattern trie needs no automaton. Build/Decode detect the chain shape, recover the pattern from the transition table (no wire-format change), and Match/Walk/MatchFirst dispatch to substring searchers: IndexByte over the pattern's rarest byte with a second-byte probe on sparse input, and a two-lane SWAR scan testing the two rarest bytes simultaneously (~4.4GB/s flat) when a density sample says candidates are common. Advancing by the pattern's KMP period after each hit keeps overlapping-occurrence scans linear on periodic patterns.

`bytes.Index` is deliberately not used: with a common first byte over prose it degrades to ~2GB/s on arm64 (candidates from the first byte only).

**Measured** (Graviton3, n=8, cpu=1): MatchFirstLate **-38%**, Anchor **-21%**; multi-pattern guard rows unchanged. Superseded on kernel arches by the NEON/SSE2 PRs later in this chain (-77%/-85%).

**Verification**: detection/period/roundtrip unit tests, differential vs the naive reference for both strategies across sizes and periodic patterns, full suite + race + fuzz.

Part 1/6 of the cross-language optimization round (see ac-xbench baseline report).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Added an optimized search path for tries containing a single pattern.
  * Improved matching efficiency for short, overlapping, periodic, and UTF-8 patterns.
  * Preserved support for full-result searches, first-match searches, and callback-based iteration.
  * Single-pattern data is rebuilt when loading encoded tries.
* **Bug Fixes**
  * Added safeguards to disable optimized matching when trie data is invalid or noncanonical.
* **Tests**
  * Expanded coverage for matching accuracy, overlaps, early termination, serialization round trips, and randomized scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->