### PR TITLE
perf: sample stop-byte density at most once per Match

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -829,20 +829,30 @@ const parallelSparseMin = 128 << 10
 // sample so a process that can never parallelize (maxProcs 1) does not
 // pay for sampling it cannot act on.
 func (tr *Trie) parallelWorkers(input []byte, maxProcs int) int {
+	p, _, _ := tr.parallelWorkersDense(input, maxProcs)
+	return p
+}
+
+// parallelWorkersDense is parallelWorkers, additionally returning the
+// stop-byte density verdict when the sparse check sampled it (valid iff
+// denseKnown): the sample costs three vectorized bytes.Count calls, and
+// the sequential dual-cursor gate wants the same signal, so a sequential
+// verdict hands it down instead of sampling the input twice.
+func (tr *Trie) parallelWorkersDense(input []byte, maxProcs int) (p int, dense, denseKnown bool) {
 	// A one-pattern trie scans with vectorized substring search at
 	// memory bandwidth (see single.go); worker goroutines and the
 	// density gates below cannot beat it.
 	if tr.single != nil {
-		return 0
+		return 0, false, false
 	}
 	if len(input) < parallelMin {
-		return 0
+		return 0, false, false
 	}
 	// Cap at 8 workers while each holds only a few parallelChunk-sized
 	// KB: more of them mainly adds wakeup and steal latency while the
 	// merge fan-in grows. Ramp toward parallelWorkersMax as slices
 	// reach parallelChunkWide, where the extra workers amortize.
-	p := min(maxProcs, len(input)/parallelChunk, 8)
+	p = min(maxProcs, len(input)/parallelChunk, 8)
 	if wide := min(maxProcs, len(input)/parallelChunkWide, parallelWorkersMax); wide > p {
 		p = wide
 	}
@@ -868,28 +878,35 @@ func (tr *Trie) parallelWorkers(input []byte, maxProcs int) int {
 		p = min(p, len(input)/(overlap*4))
 	}
 	if p < 2 {
-		return 0
+		return 0, false, false
 	}
 	// Between the two thresholds, a single-stop-byte automaton stays
 	// sequential on sparse input; past parallelSparseMin both floors
 	// are cleared, so the sample is skipped outright.
-	if len(input) < parallelSparseMin && len(tr.rootStopBytes) == 1 &&
-		!looksDense(input, tr.rootStopBytes[0]) {
-		return 0
+	if len(input) < parallelSparseMin && len(tr.rootStopBytes) == 1 {
+		dense = looksDense(input, tr.rootStopBytes[0])
+		if !dense {
+			return 0, false, true
+		}
+		return p, true, true
 	}
-	return p
+	return p, false, false
 }
 
 // Match runs the Aho-Corasick string-search algorithm on a byte input.
 func (tr *Trie) Match(input []byte) []*Match {
-	if p := tr.parallelWorkers(input, runtime.GOMAXPROCS(0)); p > 0 {
+	// When the parallel gate sampled stop-byte density and the scan
+	// stays sequential, its verdict is threaded to matchSeq so the
+	// dual-cursor gate does not sample the same input again.
+	p, dense, denseKnown := tr.parallelWorkersDense(input, runtime.GOMAXPROCS(0))
+	if p > 0 {
 		return tr.matchParallel(input, p)
 	}
 
 	buf := tr.bufPool.Get().(*matchBuf)
 	buf.reset()
 
-	tr.matchSeq(input, buf)
+	tr.matchSeqDense(input, buf, dense, denseKnown)
 
 	if len(buf.raw) == 0 {
 		tr.bufPool.Put(buf)
@@ -1015,8 +1032,19 @@ const dualChainFloor = 10
 // prefix) are outvoted by the windows that saw the input's real shape
 // instead of deciding for them.
 func (tr *Trie) dualWorthwhile(input []byte) bool {
-	dense := looksDense(input, tr.rootStopBytes[0])
+	return tr.dualWorthwhileDense(input, false, false)
+}
+
+// dualWorthwhileDense is dualWorthwhile with an optional precomputed
+// stop-byte density verdict (valid when denseKnown): Match's parallel
+// gate may already have sampled the input. Density is also now sampled
+// lazily — only on the paths that consult it — so a decisive chain
+// vote pays for no density sample at all.
+func (tr *Trie) dualWorthwhileDense(input []byte, dense, denseKnown bool) bool {
 	if len(input) < dualChainFloor*(int(tr.maxLen)+1024) {
+		if !denseKnown {
+			dense = looksDense(input, tr.rootStopBytes[0])
+		}
 		return dense
 	}
 	long, short := tr.chainSample(input)
@@ -1025,6 +1053,9 @@ func (tr *Trie) dualWorthwhile(input []byte) bool {
 	}
 	if short > long {
 		return false
+	}
+	if !denseKnown {
+		dense = looksDense(input, tr.rootStopBytes[0])
 	}
 	return dense
 }
@@ -1175,6 +1206,14 @@ func (tr *Trie) rootLively(input []byte) bool {
 
 // matchSeq scans input sequentially into buf.
 func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
+	tr.matchSeqDense(input, buf, false, false)
+}
+
+// matchSeqDense is matchSeq with an optional precomputed stop-byte
+// density verdict (valid when denseKnown): Match's parallel gate may
+// already have sampled the input, and the sample costs real time
+// against skip-dominated scans.
+func (tr *Trie) matchSeqDense(input []byte, buf *matchBuf, dense, denseKnown bool) {
 	if tr.single != nil {
 		tr.matchSingle(input, buf)
 		return
@@ -1186,7 +1225,7 @@ func (tr *Trie) matchSeq(input []byte, buf *matchBuf) {
 		// fallback signal) says overlapping two transition chains beats
 		// the single-cursor loop's inline root skip.
 		if len(input) >= dualThreshold && int(tr.maxLen)*4 < len(input)/2 &&
-			tr.dualWorthwhile(input) {
+			tr.dualWorthwhileDense(input, dense, denseKnown) {
 			tr.matchDualStopByte16(input, buf)
 			return
 		}

--- a/trie.go
+++ b/trie.go
@@ -838,6 +838,11 @@ func (tr *Trie) parallelWorkers(input []byte, maxProcs int) int {
 // denseKnown): the sample costs three vectorized bytes.Count calls, and
 // the sequential dual-cursor gate wants the same signal, so a sequential
 // verdict hands it down instead of sampling the input twice.
+//
+// The two sampled return sites are asymmetric: a dense verdict clears
+// the sparse gate and returns p > 0, so (p=0, denseKnown=true) always
+// carries dense=false — the only sampled tuple a sequential caller ever
+// sees. (p=0, dense=true, denseKnown=true) is not a possible output.
 func (tr *Trie) parallelWorkersDense(input []byte, maxProcs int) (p int, dense, denseKnown bool) {
 	// A one-pattern trie scans with vectorized substring search at
 	// memory bandwidth (see single.go); worker goroutines and the
@@ -897,7 +902,13 @@ func (tr *Trie) parallelWorkersDense(input []byte, maxProcs int) (p int, dense, 
 func (tr *Trie) Match(input []byte) []*Match {
 	// When the parallel gate sampled stop-byte density and the scan
 	// stays sequential, its verdict is threaded to matchSeq so the
-	// dual-cursor gate does not sample the same input again.
+	// dual-cursor gate does not sample the same input again. The
+	// at-most-one-sample guarantee is therefore sequential-only: the
+	// parallel branch deliberately leaves each worker to route its own
+	// chunk (dualWorthwhileDense samples chunk-local shape, which can
+	// differ from the whole input's), so a dense-verdict dispatch pays
+	// one whole-input sample here plus up to one chunk-local sample per
+	// worker inside matchParallel.
 	p, dense, denseKnown := tr.parallelWorkersDense(input, runtime.GOMAXPROCS(0))
 	if p > 0 {
 		return tr.matchParallel(input, p)
@@ -1801,6 +1812,11 @@ func (tr *Trie) matchParallel(input []byte, p int) []*Match {
 	chunk := (len(input) + p - 1) / p
 	if overlap*4 > chunk {
 		// Overlap rescanning would dominate; not worth parallelizing.
+		// Unreachable when p comes from parallelWorkersDense, which
+		// caps p at len(input)/(overlap*4) so chunk >= overlap*4; it
+		// guards direct callers (tests inject arbitrary p), which is
+		// why the matchSeq below re-derives its own routing rather
+		// than taking a threaded density verdict.
 		p = 0
 	}
 


### PR DESCRIPTION
The parallel gate's sparse check samples density (three vectorized bytes.Count calls), and the sequential dual-cursor gate wants the same signal — previously it re-sampled the same input. parallelWorkersDense now hands the verdict down to matchSeq, and dualWorthwhileDense computes density lazily, so a decisive chain vote pays for no density sample at all.

**Measured** (Graviton3, n=8): NoMatch/single-stop-100k **-4.1%**, PubNoMatch/sorted-100k **-3.5%**; everything else unchanged (skip-dominated scans are where a redundant 3KB sample is visible).

Part 2/6.