### PR TITLE
perf: widen the root-skip IndexByte escape window to 4KB

### DIFF
--- a/trie.go
+++ b/trie.go
@@ -533,9 +533,9 @@ func (tr *Trie) skipRootTable(input []byte, i int) int {
 }
 
 // skipRootIndex finds the next stop byte at or after i with one
-// bytes.IndexByte pass per stop value over successive 2KB windows.
+// bytes.IndexByte pass per stop value over successive 4KB windows.
 func (tr *Trie) skipRootIndex(input []byte, i int) int {
-	const window = 2048
+	const window = 4096
 	inputLen := len(input)
 	for i < inputLen {
 		end := min(i+window, inputLen)

--- a/trie.go
+++ b/trie.go
@@ -535,6 +535,8 @@ func (tr *Trie) skipRootTable(input []byte, i int) int {
 // skipRootIndex finds the next stop byte at or after i with one
 // bytes.IndexByte pass per stop value over successive 4KB windows.
 func (tr *Trie) skipRootIndex(input []byte, i int) int {
+	// 4KB was the best balance on Graviton3 across no-match and prose;
+	// larger windows improved no-match throughput but regressed prose.
 	const window = 4096
 	inputLen := len(input)
 	for i < inputLen {


### PR DESCRIPTION
Window sweep on Graviton3 (2/4/8/16KB): 4KB is the balanced point, **-3.8%** on Skip2 no-match and -1.4% on Skip2 prose vs 2KB; 8KB wins another 2% on pure no-match but gives it back with interest on prose overshoot. The remaining gap to a one-pass memchr2 (~4.7 vs 3.9us per 100KB) is structural — two vectorized passes over the window vs one — and is closed by the NEON kernel in the next PR.

Part 4/6.