### PR TITLE
perf: NEON search kernels for pair-filter and two-value scans (arm64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        # ubuntu-24.04-arm assembles index_arm64.s and runs the NEON
+        # kernel differential and guard-page tests natively; ubuntu-24.04
+        # covers the portable paths on amd64.
+        os: [ubuntu-24.04, ubuntu-24.04-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: gofmt
+        run: test -z "$(gofmt -l .)"
+      - name: vet
+        run: go vet ./...
+      - name: test
+        run: go test ./...
+      - name: vet and test with purego tag
+        run: |
+          go vet -tags purego ./...
+          go test -tags purego ./...
+      - name: cross-compile vet for other arm64 targets
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: |
+          for goos in darwin windows freebsd netbsd openbsd; do
+            echo "vet GOOS=$goos GOARCH=arm64"
+            GOOS=$goos GOARCH=arm64 go vet ./...
+          done

--- a/index_arm64.go
+++ b/index_arm64.go
@@ -1,0 +1,35 @@
+//go:build arm64 && !purego
+
+package ahocorasick
+
+// Per-kernel availability constants: call sites branch on these, so
+// unused strategies compile away. On arm64 both NEON kernels beat the
+// portable strategies (single-pass NEON vs SWAR or dual-pass windowed
+// IndexByte).
+const (
+	hasPairKernel = true
+	hasOr2Kernel  = true
+)
+
+// indexPair2Asm returns the smallest i in [0, m&^31) with p[i] == a and
+// p[i+d] == b, or -1 when the full 32-byte blocks contain no such
+// position (the caller scans the remaining tail with scalar code).
+// The caller must guarantee p[0 : m&^31 + d] is readable.
+//
+//go:noescape
+func indexPair2Asm(p *byte, m int, a, b byte, d int) int
+
+// indexOr2Asm returns the smallest i in [0, m&^31) with p[i] == a or
+// p[i] == b, or -1 when the full blocks contain neither value. Reads
+// p[0 : m&^31] only.
+//
+//go:noescape
+func indexOr2Asm(p *byte, m int, a, b byte) int
+
+func indexPair2(p []byte, m int, a, b byte, d int) int {
+	return indexPair2Asm(&p[0], m, a, b, d)
+}
+
+func indexOr2(p []byte, m int, a, b byte) int {
+	return indexOr2Asm(&p[0], m, a, b)
+}

--- a/index_arm64.s
+++ b/index_arm64.s
@@ -1,0 +1,122 @@
+// NEON search kernels for the single-pattern fast path and the two-value
+// root skip. Both follow the internal/bytealg syndrome idiom: compare 32
+// input bytes per iteration, AND the match mask with the magic constant
+// 0x40100401 (bytes of each 4-byte group get distinct bits 1/4/16/64),
+// then two pairwise adds fold the 256-bit mask into a 64-bit syndrome
+// with two bits per input byte, in input order. RBIT+CLZ converts the
+// first set bit into the matching byte's offset.
+//
+// Neither kernel reads past its caller-proven region: both process only
+// full 32-byte blocks and report "no hit in the full blocks" with -1;
+// the Go callers finish the < 32-byte tail with scalar code.
+
+//go:build !purego
+
+#include "textflag.h"
+
+// func indexPair2Asm(p *byte, m int, a byte, b byte, d int) int
+//
+// Returns the smallest i in [0, m&^31) with p[i] == a && p[i+d] == b,
+// or -1 if there is none. The caller guarantees p[0 : m&^31 + d] is
+// readable (stream B reads p[d : d+(m&^31)]).
+TEXT ·indexPair2Asm(SB), NOSPLIT, $0-40
+	MOVD	p+0(FP), R0
+	MOVD	m+8(FP), R1
+	MOVBU	a+16(FP), R2
+	MOVBU	b+17(FP), R3
+	MOVD	d+24(FP), R4
+	ADD	R0, R4, R4      // stream B cursor = p + d
+	VMOV	R2, V0.B16      // broadcast a
+	VMOV	R3, V7.B16      // broadcast b
+	MOVD	$0x40100401, R5
+	VMOV	R5, V5.S4       // syndrome magic
+	MOVD	ZR, R6          // positions consumed
+
+loop:
+	SUB	R6, R1, R7      // remaining positions
+	CMP	$32, R7
+	BLT	notfound
+	VLD1.P	32(R0), [V1.B16, V2.B16]
+	VLD1.P	32(R4), [V3.B16, V4.B16]
+	VCMEQ	V0.B16, V1.B16, V1.B16
+	VCMEQ	V0.B16, V2.B16, V2.B16
+	VCMEQ	V7.B16, V3.B16, V3.B16
+	VCMEQ	V7.B16, V4.B16, V4.B16
+	VAND	V3.B16, V1.B16, V3.B16  // pair condition, bytes 0-15
+	VAND	V4.B16, V2.B16, V4.B16  // pair condition, bytes 16-31
+	// Cheap existence check in the hot loop (bytealg idiom); the
+	// positional syndrome is computed only after a hit.
+	VORR	V4.B16, V3.B16, V6.B16
+	VADDP	V6.D2, V6.D2, V6.D2
+	VMOV	V6.D[0], R8
+	CBNZ	R8, found
+	ADD	$32, R6
+	B	loop
+
+found:
+	VAND	V5.B16, V3.B16, V3.B16
+	VAND	V5.B16, V4.B16, V4.B16
+	VADDP	V4.B16, V3.B16, V6.B16  // 256 -> 128
+	VADDP	V6.B16, V6.B16, V6.B16  // 128 -> 64
+	VMOV	V6.D[0], R8
+	RBIT	R8, R8
+	CLZ	R8, R8
+	ADD	R8>>1, R6, R0   // index = consumed + syndrome-bit/2
+	MOVD	R0, ret+32(FP)
+	RET
+
+notfound:
+	MOVD	$-1, R0
+	MOVD	R0, ret+32(FP)
+	RET
+
+// func indexOr2Asm(p *byte, m int, a byte, b byte) int
+//
+// Returns the smallest i in [0, m&^31) with p[i] == a || p[i] == b, or
+// -1 if there is none. Reads p[0 : m&^31] only.
+TEXT ·indexOr2Asm(SB), NOSPLIT, $0-32
+	MOVD	p+0(FP), R0
+	MOVD	m+8(FP), R1
+	MOVBU	a+16(FP), R2
+	MOVBU	b+17(FP), R3
+	VMOV	R2, V0.B16
+	VMOV	R3, V7.B16
+	MOVD	$0x40100401, R5
+	VMOV	R5, V5.S4
+	MOVD	ZR, R6
+
+loop:
+	SUB	R6, R1, R7
+	CMP	$32, R7
+	BLT	notfound
+	VLD1.P	32(R0), [V1.B16, V2.B16]
+	VCMEQ	V0.B16, V1.B16, V3.B16
+	VCMEQ	V0.B16, V2.B16, V4.B16
+	VCMEQ	V7.B16, V1.B16, V8.B16
+	VCMEQ	V7.B16, V2.B16, V9.B16
+	VORR	V8.B16, V3.B16, V3.B16
+	VORR	V9.B16, V4.B16, V4.B16
+	// Cheap existence check; positional syndrome only after a hit.
+	VORR	V4.B16, V3.B16, V6.B16
+	VADDP	V6.D2, V6.D2, V6.D2
+	VMOV	V6.D[0], R8
+	CBNZ	R8, found
+	ADD	$32, R6
+	B	loop
+
+found:
+	VAND	V5.B16, V3.B16, V3.B16
+	VAND	V5.B16, V4.B16, V4.B16
+	VADDP	V4.B16, V3.B16, V6.B16
+	VADDP	V6.B16, V6.B16, V6.B16
+	VMOV	V6.D[0], R8
+	RBIT	R8, R8
+	CLZ	R8, R8
+	ADD	R8>>1, R6, R0
+	MOVD	R0, ret+24(FP)
+	RET
+
+notfound:
+	MOVD	$-1, R0
+	MOVD	R0, ret+24(FP)
+	RET

--- a/index_generic.go
+++ b/index_generic.go
@@ -1,0 +1,16 @@
+//go:build !arm64 || purego
+
+package ahocorasick
+
+// No vector search kernels on this build: the scan paths use the
+// portable strategies (rare-byte IndexByte, SWAR pair scan, windowed
+// per-value IndexByte). The stubs below are never called; call sites
+// are gated on the constant and eliminated at compile time.
+const (
+	hasPairKernel = false
+	hasOr2Kernel  = false
+)
+
+func indexPair2(p []byte, m int, a, b byte, d int) int { panic("unreachable") }
+
+func indexOr2(p []byte, m int, a, b byte) int { panic("unreachable") }

--- a/index_kernel_bench_test.go
+++ b/index_kernel_bench_test.go
@@ -1,0 +1,28 @@
+//go:build arm64 && !purego
+
+package ahocorasick
+
+import (
+	"bytes"
+	"testing"
+)
+
+func BenchmarkKernelPair2(b *testing.B) {
+	p := bytes.Repeat([]byte{'x'}, 100032)
+	b.SetBytes(100000)
+	for n := 0; n < b.N; n++ {
+		if indexPair2(p, 100000, 'A', 'B', 3) != -1 {
+			b.Fatal("unexpected hit")
+		}
+	}
+}
+
+func BenchmarkKernelOr2(b *testing.B) {
+	p := bytes.Repeat([]byte{'x'}, 100032)
+	b.SetBytes(100000)
+	for n := 0; n < b.N; n++ {
+		if indexOr2(p, 100000, 'A', 'B') != -1 {
+			b.Fatal("unexpected hit")
+		}
+	}
+}

--- a/index_kernel_test.go
+++ b/index_kernel_test.go
@@ -1,0 +1,115 @@
+//go:build arm64 && !purego
+
+package ahocorasick
+
+// Kernel-level tests for the vector search kernels: exhaustive differential
+// against scalar oracles across sizes, positions, and pair distances. The
+// guard-page test proving the read contracts lives in
+// index_kernel_unix_test.go (mmap/mprotect are unix-only).
+
+import (
+	"math/rand"
+	"testing"
+)
+
+func oraclePair2(p []byte, m int, a, b byte, d int) int {
+	m &^= 31
+	for i := 0; i < m; i++ {
+		if p[i] == a && p[i+d] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+func oracleOr2(p []byte, m int, a, b byte) int {
+	m &^= 31
+	for i := 0; i < m; i++ {
+		if p[i] == a || p[i] == b {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestIndexPair2Exhaustive(t *testing.T) {
+	// Sizes crossing every block boundary; hit planted at every position;
+	// distances covering typical pattern spans plus the beyond-one-block
+	// cases (d is bounded only by pattern length, so d > 32 must place
+	// stream B more than a whole block past stream A).
+	for _, m := range []int{0, 1, 31, 32, 33, 63, 64, 65, 96, 127, 130} {
+		for _, d := range []int{1, 2, 5, 7, 15, 32, 33, 64, 100} {
+			buf := make([]byte, m+d)
+			for i := range buf {
+				buf[i] = 'x'
+			}
+			// No hit anywhere.
+			if got := indexPair2(append([]byte{}, buf...), m, 'A', 'B', d); m > 0 && got != -1 {
+				t.Fatalf("m=%d d=%d empty: got %d want -1", m, d, got)
+			}
+			for pos := 0; pos < m; pos++ {
+				p := append([]byte{}, buf...)
+				p[pos] = 'A'
+				p[pos+d] = 'B'
+				want := oraclePair2(p, m, 'A', 'B', d)
+				got := indexPair2(p, m, 'A', 'B', d)
+				if got != want {
+					t.Fatalf("m=%d d=%d pos=%d: got %d want %d", m, d, pos, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestIndexPair2EqualBytes(t *testing.T) {
+	// a == b and overlapping planted pairs.
+	p := make([]byte, 128)
+	for i := range p {
+		p[i] = 'x'
+	}
+	p[40], p[43] = 'z', 'z'
+	if got, want := indexPair2(p, 96, 'z', 'z', 3), 40; got != want {
+		t.Fatalf("got %d want %d", got, want)
+	}
+}
+
+func TestIndexOr2Exhaustive(t *testing.T) {
+	for _, m := range []int{0, 1, 31, 32, 33, 64, 65, 127, 130} {
+		buf := make([]byte, m)
+		for i := range buf {
+			buf[i] = 'x'
+		}
+		for pos := 0; pos < m; pos++ {
+			for _, c := range []byte{'A', 'B'} {
+				p := append([]byte{}, buf...)
+				p[pos] = c
+				want := oracleOr2(p, m, 'A', 'B')
+				got := indexOr2(p, m, 'A', 'B')
+				if got != want {
+					t.Fatalf("m=%d pos=%d c=%c: got %d want %d", m, pos, c, got, want)
+				}
+			}
+		}
+	}
+}
+
+func TestIndexKernelsRandomDifferential(t *testing.T) {
+	rng := rand.New(rand.NewSource(77))
+	for iter := 0; iter < 5000; iter++ {
+		m := rng.Intn(300)
+		d := 1 + rng.Intn(16)
+		p := make([]byte, m+d)
+		for i := range p {
+			p[i] = byte('a' + rng.Intn(4)) // small alphabet: many hits
+		}
+		a, b := byte('a'+rng.Intn(4)), byte('a'+rng.Intn(4))
+		if m > 0 {
+			if got, want := indexPair2(p, m, a, b, d), oraclePair2(p, m, a, b, d); got != want {
+				t.Fatalf("pair m=%d d=%d a=%c b=%c: got %d want %d (%q)", m, d, a, b, got, want, p)
+			}
+			if got, want := indexOr2(p, m, a, b), oracleOr2(p, m, a, b); got != want {
+				t.Fatalf("or m=%d a=%c b=%c: got %d want %d (%q)", m, a, b, got, want, p)
+			}
+		}
+	}
+}

--- a/index_kernel_unix_test.go
+++ b/index_kernel_unix_test.go
@@ -1,0 +1,62 @@
+//go:build arm64 && !purego && unix
+
+package ahocorasick
+
+// Guard-page proof of the kernels' read contracts: indexPair2 reads
+// p[0 : m&^31 + d], indexOr2 reads p[0 : m&^31]. The buffers end exactly
+// at a PROT_NONE page, so one byte of overread segfaults the test.
+// Separate file: mmap/mprotect exist only on unix.
+
+import (
+	"syscall"
+	"testing"
+)
+
+// guardedBuf returns a slice of n bytes whose LAST byte sits immediately
+// before an inaccessible page: any read past p[n-1] faults deterministically.
+func guardedBuf(t *testing.T, n int) []byte {
+	t.Helper()
+	pg := syscall.Getpagesize()
+	pages := (n+pg-1)/pg + 1
+	mem, err := syscall.Mmap(-1, 0, pages*pg, syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_ANON|syscall.MAP_PRIVATE)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { syscall.Munmap(mem) })
+	guard := mem[(pages-1)*pg:]
+	if err := syscall.Mprotect(guard, syscall.PROT_NONE); err != nil {
+		t.Fatal(err)
+	}
+	return mem[(pages-1)*pg-n : (pages-1)*pg]
+}
+
+func TestIndexKernelsGuardPage(t *testing.T) {
+	for _, m := range []int{32, 33, 63, 64, 96, 127, 128, 4096} {
+		for _, d := range []int{1, 7, 32, 33, 100} {
+			n := m&^31 + d // exactly the documented readable region
+			p := guardedBuf(t, n)
+			for i := range p {
+				p[i] = 'x'
+			}
+			_ = indexPair2(p, m, 'A', 'B', d)
+			// Plant a hit in the last block to force full reads.
+			if m&^31 > 0 {
+				p[m&^31-1] = 'A'
+				if m&^31-1+d < n {
+					p[m&^31-1+d] = 'B'
+				}
+				_ = indexPair2(p, m, 'A', 'B', d)
+			}
+		}
+		p := guardedBuf(t, m&^31)
+		for i := range p {
+			p[i] = 'x'
+		}
+		_ = indexOr2(p, m, 'A', 'B')
+		if m&^31 > 0 {
+			p[m&^31-1] = 'B'
+			_ = indexOr2(p, m, 'A', 'B')
+		}
+	}
+}

--- a/index_kernel_unix_test.go
+++ b/index_kernel_unix_test.go
@@ -1,11 +1,12 @@
-//go:build arm64 && !purego && unix
+//go:build arm64 && !purego && (linux || darwin)
 
 package ahocorasick
 
 // Guard-page proof of the kernels' read contracts: indexPair2 reads
 // p[0 : m&^31 + d], indexOr2 reads p[0 : m&^31]. The buffers end exactly
 // at a PROT_NONE page, so one byte of overread segfaults the test.
-// Separate file: mmap/mprotect exist only on unix.
+// Separate file: the std syscall package exposes Mmap/Mprotect only on
+// linux and darwin among arm64 targets (the BSDs moved them to x/sys).
 
 import (
 	"syscall"

--- a/single.go
+++ b/single.go
@@ -452,7 +452,12 @@ func (tr *Trie) singlePairMatchFrom(input []byte, from int, buf *matchBuf) {
 	// to a plain load on little-endian targets). The intersected
 	// swarZero masks can carry borrow false positives (see swarZero);
 	// singleVerifyCarry, not the mask, is the correctness boundary.
-	for ; i+ob+16 <= len(input); i += 16 {
+	// The lane loop is bounded by the last valid start (i+15 <= limit),
+	// not by len(input): a long pattern with early filter offsets would
+	// otherwise enumerate dense candidates past limit only to discard
+	// them. That bound also proves the loads in range — i+ob+15 <=
+	// limit+ob = len(input)-n+ob <= len(input)-1 since ob <= n-1.
+	for ; i+16 <= limit+1; i += 16 {
 		wA := input[i+oa : i+oa+16]
 		wB := input[i+ob : i+ob+16]
 		wa0 := binary.LittleEndian.Uint64(wA)
@@ -525,8 +530,8 @@ func (tr *Trie) singlePairWalkFrom(input []byte, start int, fn WalkFn) {
 	next := start
 	prev := -1
 	i := start
-	// Same two-lane structure as singlePairMatch.
-	for ; i+ob+16 <= len(input); i += 16 {
+	// Same two-lane structure (and lane-loop bound) as singlePairMatch.
+	for ; i+16 <= limit+1; i += 16 {
 		wA := input[i+oa : i+oa+16]
 		wB := input[i+ob : i+ob+16]
 		wa0 := binary.LittleEndian.Uint64(wA)
@@ -602,10 +607,12 @@ func swarZero(w uint64) uint64 {
 // Only called when hasPairKernel.
 //
 // Position mapping: pattern start s puts the low-offset filter byte at
-// input[s+oa], so the kernel scans input[oa:] and its index j IS the
-// candidate start. Read contract: the kernel touches at most
-// input[oa : oa + (limit+1)&^31 + (ob-oa)], which stays inside input
-// because ob <= n-1 and limit = len(input)-n.
+// input[s+oa], so each call scans input[s+oa:] and its index j offsets
+// from s. Read contract, per call: with m = limit-s+1 candidate starts
+// remaining, the kernel reads at most input[s+oa : s+oa+m&^31+(ob-oa)]
+// (see the guard-page test). Since m&^31 <= m, the exclusive end is at
+// most s+oa+(limit-s+1)+(ob-oa) = limit+ob+1 <= len(input), because
+// ob <= n-1 and limit = len(input)-n.
 func (tr *Trie) singleKernelMatch(input []byte, buf *matchBuf) {
 	p := tr.single
 	n := len(p)
@@ -619,15 +626,25 @@ func (tr *Trie) singleKernelMatch(input []byte, buf *matchBuf) {
 	limit := len(input) - n // last valid start
 	s := 0
 	candidates := 0
+	anchor := 0 // window start for the density measurement
 	for s <= limit {
 		// Adaptive bailout: each kernel return costs a call restart
-		// (~17ns), so a pair-dense stream (>1 candidate per 64 bytes,
-		// after a 32-candidate grace) is better served by the SWAR
-		// scan with inline candidate handling. Bounded regret: at
-		// most ~2KB scanned the slow way before switching.
-		if candidates++; candidates > 32 && candidates*64 > s {
-			tr.singlePairMatchFrom(input, s, buf)
-			return
+		// (~17ns), so a pair-dense stream (>1 candidate per 64 bytes)
+		// is better served by the SWAR scan with inline candidate
+		// handling. Density is measured over a tumbling window — 32
+		// candidates against the bytes covered since the window began —
+		// never against the absolute offset, so a dense region reached
+		// after a long sparse prefix still trips the switch within two
+		// windows. Bounded regret: at most ~64 restarts (~4KB scanned
+		// the slow way) before switching.
+		if candidates++; candidates > 32 {
+			if candidates*64 > s-anchor {
+				tr.singlePairMatchFrom(input, s, buf)
+				return
+			}
+			// Sparse window: restart the measurement here.
+			candidates = 0
+			anchor = s
 		}
 		m := limit - s + 1 // candidate starts remaining
 		j := indexPair2(input[s+oa:], m, a, b, d)
@@ -665,11 +682,16 @@ func (tr *Trie) singleKernelWalk(input []byte, fn WalkFn) {
 	limit := len(input) - n
 	s := 0
 	candidates := 0
+	anchor := 0
 	for s <= limit {
 		// See singleKernelMatch for the adaptive bailout.
-		if candidates++; candidates > 32 && candidates*64 > s {
-			tr.singlePairWalkFrom(input, s, fn)
-			return
+		if candidates++; candidates > 32 {
+			if candidates*64 > s-anchor {
+				tr.singlePairWalkFrom(input, s, fn)
+				return
+			}
+			candidates = 0
+			anchor = s
 		}
 		m := limit - s + 1
 		j := indexPair2(input[s+oa:], m, a, b, d)

--- a/single.go
+++ b/single.go
@@ -223,6 +223,10 @@ func (tr *Trie) matchSingle(input []byte, buf *matchBuf) {
 			buf.raw = append(buf.raw, uint64(i), dp)
 		}
 	}
+	if hasPairKernel {
+		tr.singleKernelMatch(input, buf)
+		return
+	}
 	if tr.singlePairDense(input) {
 		tr.singlePairMatch(input, buf)
 		return
@@ -245,6 +249,10 @@ func (tr *Trie) walkSingle(input []byte, fn WalkFn) {
 				return
 			}
 		}
+	}
+	if hasPairKernel {
+		tr.singleKernelWalk(input, fn)
+		return
 	}
 	if tr.singlePairDense(input) {
 		tr.singlePairWalk(input, fn)
@@ -311,6 +319,12 @@ func (tr *Trie) singleRareWalk(input []byte, fn WalkFn) {
 // their offsets simultaneously, eight candidate starts per iteration.
 // Requires len(tr.single) >= 2.
 func (tr *Trie) singlePairMatch(input []byte, buf *matchBuf) {
+	tr.singlePairMatchFrom(input, 0, buf)
+}
+
+// singlePairMatchFrom is singlePairMatch starting at position from; the
+// kernel path hands over here when the candidate stream turns out dense.
+func (tr *Trie) singlePairMatchFrom(input []byte, from int, buf *matchBuf) {
 	p := tr.single
 	n := len(p)
 	oa, ob := tr.singleO1, tr.singleO2
@@ -322,8 +336,8 @@ func (tr *Trie) singlePairMatch(input []byte, buf *matchBuf) {
 	dp := tr.singleDP
 
 	limit := len(input) - n // last valid start
-	next := 0               // next start allowed by the KMP period
-	i := 0
+	next := from            // next start allowed by the KMP period
+	i := from
 	// Two independent 8-byte lanes per iteration: the lanes share no
 	// data, so their load-xor-test chains overlap and the common no-hit
 	// case takes one branch per 16 bytes. Lane 0 hits precede lane 1
@@ -377,6 +391,11 @@ func (tr *Trie) singlePairMatch(input []byte, buf *matchBuf) {
 
 // singlePairWalk is singlePairMatch for the callback API.
 func (tr *Trie) singlePairWalk(input []byte, fn WalkFn) {
+	tr.singlePairWalkFrom(input, 0, fn)
+}
+
+// singlePairWalkFrom is singlePairWalk starting at position from.
+func (tr *Trie) singlePairWalkFrom(input []byte, from int, fn WalkFn) {
 	p := tr.single
 	n := len(p)
 	oa, ob := tr.singleO1, tr.singleO2
@@ -388,8 +407,8 @@ func (tr *Trie) singlePairWalk(input []byte, fn WalkFn) {
 	dp := tr.singleDP
 
 	limit := len(input) - n
-	next := 0
-	i := 0
+	next := from
+	i := from
 	// Same two-lane structure as singlePairMatch.
 	for ; i+ob+16 <= len(input); i += 16 {
 		wA := input[i+oa : i+oa+16]
@@ -444,4 +463,105 @@ func (tr *Trie) singlePairWalk(input []byte, fn WalkFn) {
 // is zero.
 func swarZero(w uint64) uint64 {
 	return (w - swarOnes) &^ w & swarHighs
+}
+
+// singleKernelMatch finds occurrences with the vector pair kernel: one
+// call scans whole 32-position blocks for candidates (both rare bytes at
+// their offsets), so neither the candidate-restart cost of the rare-byte
+// strategy nor the flat scalar throughput of the SWAR pair scan applies.
+// Only called when hasPairKernel.
+//
+// Position mapping: pattern start s puts the low-offset filter byte at
+// input[s+oa], so the kernel scans input[oa:] and its index j IS the
+// candidate start. Read contract: the kernel touches at most
+// input[oa : oa + (limit+1)&^31 + (ob-oa)], which stays inside input
+// because ob <= n-1 and limit = len(input)-n.
+func (tr *Trie) singleKernelMatch(input []byte, buf *matchBuf) {
+	p := tr.single
+	n := len(p)
+	oa, ob := tr.singleO1, tr.singleO2
+	if oa > ob {
+		oa, ob = ob, oa
+	}
+	a, b := p[oa], p[ob]
+	d := ob - oa
+	dp := tr.singleDP
+	limit := len(input) - n // last valid start
+	s := 0
+	candidates := 0
+	for s <= limit {
+		// Adaptive bailout: each kernel return costs a call restart
+		// (~17ns), so a pair-dense stream (>1 candidate per 64 bytes,
+		// after a 32-candidate grace) is better served by the SWAR
+		// scan with inline candidate handling. Bounded regret: at
+		// most ~2KB scanned the slow way before switching.
+		if candidates++; candidates > 32 && candidates*64 > s {
+			tr.singlePairMatchFrom(input, s, buf)
+			return
+		}
+		m := limit - s + 1 // candidate starts remaining
+		j := indexPair2(input[s+oa:], m, a, b, d)
+		if j < 0 {
+			// Scalar tail over the last partial block.
+			for t := s + m&^31; t <= limit; t++ {
+				if input[t+oa] == a && input[t+ob] == b && singleVerify(input, t, p) {
+					buf.raw = append(buf.raw, uint64(t+n-1), dp)
+					t += tr.singleSkip - 1
+				}
+			}
+			return
+		}
+		cand := s + j
+		if singleVerify(input, cand, p) {
+			buf.raw = append(buf.raw, uint64(cand+n-1), dp)
+			s = cand + tr.singleSkip
+		} else {
+			s = cand + 1
+		}
+	}
+}
+
+// singleKernelWalk is singleKernelMatch for the callback API.
+func (tr *Trie) singleKernelWalk(input []byte, fn WalkFn) {
+	p := tr.single
+	n := len(p)
+	oa, ob := tr.singleO1, tr.singleO2
+	if oa > ob {
+		oa, ob = ob, oa
+	}
+	a, b := p[oa], p[ob]
+	d := ob - oa
+	dp := tr.singleDP
+	limit := len(input) - n
+	s := 0
+	candidates := 0
+	for s <= limit {
+		// See singleKernelMatch for the adaptive bailout.
+		if candidates++; candidates > 32 && candidates*64 > s {
+			tr.singlePairWalkFrom(input, s, fn)
+			return
+		}
+		m := limit - s + 1
+		j := indexPair2(input[s+oa:], m, a, b, d)
+		if j < 0 {
+			for t := s + m&^31; t <= limit; t++ {
+				if input[t+oa] == a && input[t+ob] == b && singleVerify(input, t, p) {
+					if !fn(uint32(t+n-1), uint32(dp), uint32(dp>>32)) {
+						return
+					}
+					t += tr.singleSkip - 1
+				}
+			}
+			return
+		}
+		cand := s + j
+		if singleVerify(input, cand, p) {
+			if !fn(uint32(cand+n-1), uint32(dp), uint32(dp>>32)) {
+				return
+			}
+			s = cand + tr.singleSkip
+		} else {
+			s = cand + 1
+		}
+	}
 }

--- a/single.go
+++ b/single.go
@@ -311,8 +311,8 @@ func (tr *Trie) matchSingle(input []byte, buf *matchBuf) {
 // density inline over bytes it has already scanned and hands off to the
 // pair scan when the rare byte turns out to be locally common. The
 // kernel walk observes the same rule: it scans strictly forward, block
-// by block, and bails out to the pair scan inline when the candidate
-// stream turns dense.
+// by block, and hands dense stretches to the pair scan in bounded
+// spans, taking back over when the candidate stream turns sparse again.
 func (tr *Trie) walkSingle(input []byte, fn WalkFn) {
 	if len(tr.single) == 1 {
 		c := tr.single[0]
@@ -376,6 +376,13 @@ const (
 	singleSwitchSpan     = 38 // ~1/2.6%
 )
 
+// pairPhaseSpan is the span of one SWAR phase in the kernel searchers'
+// two-way handoff (singleKernelMatch): after a dense window hands over,
+// the SWAR scan runs one span at a time and control returns to the
+// kernel as soon as a span carries at most one candidate per 64 bytes —
+// the same break-even density the handoff itself encodes.
+const pairPhaseSpan = 4096
+
 // singleRareWalk is singleRareMatch for the callback API, with the lazy
 // density switch described at walkSingle: when the rare byte proves
 // locally common, hand the remainder of the input to the pair scan.
@@ -427,6 +434,17 @@ func (tr *Trie) singlePairMatch(input []byte, buf *matchBuf) {
 // singlePairMatchFrom is singlePairMatch starting at position from; the
 // kernel path hands over here when the candidate stream turns out dense.
 func (tr *Trie) singlePairMatchFrom(input []byte, from int, buf *matchBuf) {
+	tr.singlePairMatchRange(input, from, len(input)-len(tr.single)+1, buf)
+}
+
+// singlePairMatchRange scans candidate starts in [from, end) with the
+// SWAR pair loop; end <= limit+1 always. When end > limit the scan is
+// complete (including the scalar tail); otherwise the caller resumes at
+// the returned position — candidate starts before it were handled or
+// proven impossible. The second return value counts SWAR lane hits
+// observed (borrow false positives included): a density signal for the
+// kernel's phase policy, not an exact candidate count.
+func (tr *Trie) singlePairMatchRange(input []byte, from, end int, buf *matchBuf) (int, int) {
 	p := tr.single
 	n := len(p)
 	oa, ob := tr.singleO1, tr.singleO2
@@ -441,6 +459,7 @@ func (tr *Trie) singlePairMatchFrom(input []byte, from int, buf *matchBuf) {
 	limit := len(input) - n // last valid start
 	next := from            // next start allowed by the KMP period
 	prev := -1              // last confirmed match start, for the period carry
+	cands := 0
 	i := from
 	// Two independent 8-byte lanes per iteration: the lanes share no
 	// data, so their load-xor-test chains overlap and the common no-hit
@@ -452,12 +471,14 @@ func (tr *Trie) singlePairMatchFrom(input []byte, from int, buf *matchBuf) {
 	// to a plain load on little-endian targets). The intersected
 	// swarZero masks can carry borrow false positives (see swarZero);
 	// singleVerifyCarry, not the mask, is the correctness boundary.
-	// The lane loop is bounded by the last valid start (i+15 <= limit),
-	// not by len(input): a long pattern with early filter offsets would
-	// otherwise enumerate dense candidates past limit only to discard
-	// them. That bound also proves the loads in range — i+ob+15 <=
-	// limit+ob = len(input)-n+ob <= len(input)-1 since ob <= n-1.
-	for ; i+16 <= limit+1; i += 16 {
+	// The lane loop is bounded by the last valid start (i+15 <= limit,
+	// via end <= limit+1), not by len(input): a long pattern with early
+	// filter offsets would otherwise enumerate dense candidates past
+	// limit only to discard them. That bound also proves the loads in
+	// range — i+ob+15 <= limit+ob = len(input)-n+ob <= len(input)-1
+	// since ob <= n-1. Candidate counting lives only in the hit
+	// branches, so the no-hit fast path pays nothing for it.
+	for ; i+16 <= end; i += 16 {
 		wA := input[i+oa : i+oa+16]
 		wB := input[i+ob : i+ob+16]
 		wa0 := binary.LittleEndian.Uint64(wA)
@@ -472,6 +493,7 @@ func (tr *Trie) singlePairMatchFrom(input []byte, from int, buf *matchBuf) {
 		for m0 != 0 {
 			pos := i + bits.TrailingZeros64(m0)>>3
 			m0 &= m0 - 1
+			cands++
 			if pos < next || pos > limit {
 				continue
 			}
@@ -484,6 +506,7 @@ func (tr *Trie) singlePairMatchFrom(input []byte, from int, buf *matchBuf) {
 		for m1 != 0 {
 			pos := i + 8 + bits.TrailingZeros64(m1)>>3
 			m1 &= m1 - 1
+			cands++
 			if pos < next || pos > limit {
 				continue
 			}
@@ -494,6 +517,11 @@ func (tr *Trie) singlePairMatchFrom(input []byte, from int, buf *matchBuf) {
 			}
 		}
 	}
+	if end <= limit {
+		// Interior range: positions from i on are unprocessed; the
+		// caller resumes there (next carries the period constraint).
+		return max(i, next), cands
+	}
 	for pos := max(i, next); pos <= limit; pos++ {
 		if input[pos+oa] == p[oa] && input[pos+ob] == p[ob] &&
 			singleVerifyCarry(input, pos, prev, skip, p) {
@@ -502,6 +530,7 @@ func (tr *Trie) singlePairMatchFrom(input []byte, from int, buf *matchBuf) {
 			pos += skip - 1 // the loop increment adds the 1 back
 		}
 	}
+	return limit + 1, cands
 }
 
 // singlePairWalk is singlePairMatch for the callback API.
@@ -515,6 +544,13 @@ func (tr *Trie) singlePairWalk(input []byte, fn WalkFn) {
 // Candidates before start were already handled (or proven impossible)
 // by the caller.
 func (tr *Trie) singlePairWalkFrom(input []byte, start int, fn WalkFn) {
+	tr.singlePairWalkRange(input, start, len(input)-len(tr.single)+1, fn)
+}
+
+// singlePairWalkRange is singlePairMatchRange for the callback API. The
+// third return value reports whether the callback stopped the walk, in
+// which case the caller must stop too.
+func (tr *Trie) singlePairWalkRange(input []byte, from, end int, fn WalkFn) (int, int, bool) {
 	p := tr.single
 	n := len(p)
 	oa, ob := tr.singleO1, tr.singleO2
@@ -527,11 +563,13 @@ func (tr *Trie) singlePairWalkFrom(input []byte, start int, fn WalkFn) {
 	skip := tr.singleSkip
 
 	limit := len(input) - n
-	next := start
+	next := from
 	prev := -1
-	i := start
-	// Same two-lane structure (and lane-loop bound) as singlePairMatch.
-	for ; i+16 <= limit+1; i += 16 {
+	cands := 0
+	i := from
+	// Same two-lane structure (and lane-loop bound) as
+	// singlePairMatchRange.
+	for ; i+16 <= end; i += 16 {
 		wA := input[i+oa : i+oa+16]
 		wB := input[i+ob : i+ob+16]
 		wa0 := binary.LittleEndian.Uint64(wA)
@@ -546,12 +584,13 @@ func (tr *Trie) singlePairWalkFrom(input []byte, start int, fn WalkFn) {
 		for m0 != 0 {
 			pos := i + bits.TrailingZeros64(m0)>>3
 			m0 &= m0 - 1
+			cands++
 			if pos < next || pos > limit {
 				continue
 			}
 			if singleVerifyCarry(input, pos, prev, skip, p) {
 				if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
-					return
+					return pos, cands, true
 				}
 				prev = pos
 				next = pos + skip
@@ -560,28 +599,33 @@ func (tr *Trie) singlePairWalkFrom(input []byte, start int, fn WalkFn) {
 		for m1 != 0 {
 			pos := i + 8 + bits.TrailingZeros64(m1)>>3
 			m1 &= m1 - 1
+			cands++
 			if pos < next || pos > limit {
 				continue
 			}
 			if singleVerifyCarry(input, pos, prev, skip, p) {
 				if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
-					return
+					return pos, cands, true
 				}
 				prev = pos
 				next = pos + skip
 			}
 		}
 	}
+	if end <= limit {
+		return max(i, next), cands, false
+	}
 	for pos := max(i, next); pos <= limit; pos++ {
 		if input[pos+oa] == p[oa] && input[pos+ob] == p[ob] &&
 			singleVerifyCarry(input, pos, prev, skip, p) {
 			if !fn(uint32(pos+n-1), uint32(dp), uint32(dp>>32)) {
-				return
+				return pos, cands, true
 			}
 			prev = pos
 			pos += skip - 1
 		}
 	}
+	return limit + 1, cands, false
 }
 
 // swarZero returns a mask with bit 7 of each byte set for every zero
@@ -628,24 +672,6 @@ func (tr *Trie) singleKernelMatch(input []byte, buf *matchBuf) {
 	candidates := 0
 	anchor := 0 // window start for the density measurement
 	for s <= limit {
-		// Adaptive bailout: each kernel return costs a call restart
-		// (~17ns), so a pair-dense stream (>1 candidate per 64 bytes)
-		// is better served by the SWAR scan with inline candidate
-		// handling. Density is measured over a tumbling window — 32
-		// candidates against the bytes covered since the window began —
-		// never against the absolute offset, so a dense region reached
-		// after a long sparse prefix still trips the switch within two
-		// windows. Bounded regret: at most ~64 restarts (~4KB scanned
-		// the slow way) before switching.
-		if candidates++; candidates > 32 {
-			if candidates*64 > s-anchor {
-				tr.singlePairMatchFrom(input, s, buf)
-				return
-			}
-			// Sparse window: restart the measurement here.
-			candidates = 0
-			anchor = s
-		}
 		m := limit - s + 1 // candidate starts remaining
 		j := indexPair2(input[s+oa:], m, a, b, d)
 		if j < 0 {
@@ -664,6 +690,39 @@ func (tr *Trie) singleKernelMatch(input []byte, buf *matchBuf) {
 			s = cand + tr.singleSkip
 		} else {
 			s = cand + 1
+		}
+		// Adaptive phase policy: each kernel return costs a call
+		// restart (~17ns), so a pair-dense stream (>1 candidate per
+		// 64 bytes) is better served by the SWAR scan with inline
+		// candidate handling. Density is measured over a tumbling
+		// window — 32 returned candidates against the bytes they
+		// span — and evaluated only after the kernel has returned a
+		// candidate, so a candidate-free suffix is always skipped at
+		// kernel speed, never handed to the scalar scan. When a
+		// window proves dense the SWAR scan takes over span by span
+		// and hands back as soon as one span turns sparse, so
+		// neither a dense island nor a sparse tail commits the
+		// remainder of the input to the wrong strategy. Bounded
+		// regret per transition: at most ~64 restarts (~2 windows)
+		// to detect density, one ~4KB span to detect sparsity.
+		if candidates++; candidates > 32 {
+			if candidates*64 > cand-anchor {
+				// Dense: SWAR phases until a span proves sparse.
+				for s <= limit {
+					end := min(s+pairPhaseSpan, limit+1)
+					var got int
+					s, got = tr.singlePairMatchRange(input, s, end, buf)
+					if end > limit {
+						return
+					}
+					if got*64 <= pairPhaseSpan {
+						break // sparse span: back to the kernel
+					}
+				}
+			}
+			// Restart the measurement window here.
+			candidates = 0
+			anchor = s
 		}
 	}
 }
@@ -684,15 +743,6 @@ func (tr *Trie) singleKernelWalk(input []byte, fn WalkFn) {
 	candidates := 0
 	anchor := 0
 	for s <= limit {
-		// See singleKernelMatch for the adaptive bailout.
-		if candidates++; candidates > 32 {
-			if candidates*64 > s-anchor {
-				tr.singlePairWalkFrom(input, s, fn)
-				return
-			}
-			candidates = 0
-			anchor = s
-		}
 		m := limit - s + 1
 		j := indexPair2(input[s+oa:], m, a, b, d)
 		if j < 0 {
@@ -714,6 +764,25 @@ func (tr *Trie) singleKernelWalk(input []byte, fn WalkFn) {
 			s = cand + tr.singleSkip
 		} else {
 			s = cand + 1
+		}
+		// See singleKernelMatch for the adaptive phase policy.
+		if candidates++; candidates > 32 {
+			if candidates*64 > cand-anchor {
+				for s <= limit {
+					end := min(s+pairPhaseSpan, limit+1)
+					var got int
+					var stopped bool
+					s, got, stopped = tr.singlePairWalkRange(input, s, end, fn)
+					if stopped || end > limit {
+						return
+					}
+					if got*64 <= pairPhaseSpan {
+						break
+					}
+				}
+			}
+			candidates = 0
+			anchor = s
 		}
 	}
 }

--- a/singlepattern_test.go
+++ b/singlepattern_test.go
@@ -285,12 +285,15 @@ func TestSingleLargeInputs(t *testing.T) {
 	}
 }
 
-// TestSingleLongDistanceFilter drives the kernel paths with a pattern
-// whose two selected filter bytes sit more than one 32-byte block apart,
-// so the kernel's second-byte load crosses into a later block than the
-// first: candidate mapping, the per-call read bound, and the scalar tail
-// all see d > 32 through Trie-derived offsets (the direct kernel test
-// stops at d == 32 and bypasses the builder's offset selection).
+// TestSingleLongDistanceFilter drives the kernel paths end-to-end with a
+// pattern whose two selected filter bytes sit more than one 32-byte block
+// apart, so the kernel's second-byte load crosses into a later block than
+// the first. The direct differential and guard-page tests already cover
+// large d values on synthetic buffers; what is unique here is the full
+// pipeline — the builder's offset selection, candidate-position mapping,
+// and the scalar-tail handoff — driven through Trie-derived offsets and
+// checked against the reference (the read contract itself is proved by
+// the guard-page test, which this heap-backed test cannot).
 func TestSingleLongDistanceFilter(t *testing.T) {
 	// '7' (digit, rank 80) and 'Q' (uppercase, rank 85) are the two
 	// rarest bytes; every middle byte is a common lowercase letter.
@@ -455,6 +458,52 @@ func TestSingleWalkDensitySwitch(t *testing.T) {
 			want := naiveMatch([]string{pat}, input)
 			if d := diffTriples(tr.triplesFromWalk(input), want); d != -1 {
 				t.Fatalf("%q input %d: walk diverges at %d", pat, k, d)
+			}
+		}
+	}
+}
+
+// TestSinglePhaseTransitions stresses the kernel searchers' two-way
+// dense/sparse handoff (on arm64; elsewhere the sampled strategies)
+// with inputs that alternate phases: dense islands committing to the
+// SWAR scan must hand back to the kernel on the sparse stretches that
+// follow, dense suffixes must still trip the switch, and a dense island
+// followed by a candidate-free remainder must not strand the scan on
+// the slow path. Every shape is checked against the naive reference
+// through both Match and Walk.
+func TestSinglePhaseTransitions(t *testing.T) {
+	for _, pat := range []string{"ab", "abab", "aabaa", "Hedvig"} {
+		tr := NewTrieBuilder().AddString(pat).Build()
+		if tr.single == nil {
+			t.Fatalf("%q: single not detected", pat)
+		}
+		sparse := bytes.Repeat([]byte("qw"), 16384) // 32KB, no candidates
+		island := bytes.Repeat([]byte(pat), 2048/len(pat))
+
+		// Island then long sparse tail (with one late plant).
+		islandTail := append(append([]byte{}, island...), sparse...)
+		copy(islandTail[len(islandTail)-len(pat)-7:], pat)
+		// Sparse head, island, sparse tail: both transitions.
+		sandwich := append(append(append([]byte{}, sparse...), island...), sparse...)
+		// Alternating islands and gaps: repeated transitions.
+		var alternating []byte
+		for range 6 {
+			alternating = append(alternating, island...)
+			alternating = append(alternating, sparse[:4096]...)
+		}
+		// Island then candidate-free remainder: the kernel must keep
+		// the suffix (no SWAR strand) and still match the reference.
+		islandEmpty := append(append([]byte{}, island...), sparse[:16384]...)
+
+		for k, input := range [][]byte{islandTail, sandwich, alternating, islandEmpty} {
+			want := naiveMatch([]string{pat}, input)
+			ms := tr.Match(input)
+			if d := diffTriples(triplesFromMatches(ms), want); d != -1 {
+				t.Fatalf("%q input %d: Match diverges at %d", pat, k, d)
+			}
+			tr.ReleaseMatches(ms)
+			if d := diffTriples(tr.triplesFromWalk(input), want); d != -1 {
+				t.Fatalf("%q input %d: Walk diverges at %d", pat, k, d)
 			}
 		}
 	}

--- a/singlepattern_test.go
+++ b/singlepattern_test.go
@@ -244,3 +244,43 @@ func TestSingleWalkStrategiesStop(t *testing.T) {
 		}
 	}
 }
+
+// TestSingleLargeInputs exercises the large-input single-pattern paths
+// end-to-end (on arm64 the vector kernel and its adaptive handover to
+// the SWAR scan; elsewhere the sampled strategies) against the naive
+// reference: sparse prose-like input, pair-dense periodic input that
+// forces the mid-stream switch, and a hit landing in the scalar tail
+// after the last full block.
+func TestSingleLargeInputs(t *testing.T) {
+	rng := rand.New(rand.NewSource(1234))
+	for _, pattern := range []string{"ab", "aba", "Hedvig", "imorges"} {
+		tr := NewTrieBuilder().AddString(pattern).Build()
+
+		// Sparse: 64KB filler with occasional plants.
+		sparse := make([]byte, 64<<10)
+		for i := range sparse {
+			sparse[i] = byte(' ' + rng.Intn(90))
+		}
+		for k := 0; k < 40; k++ {
+			copy(sparse[rng.Intn(len(sparse)-len(pattern)):], pattern)
+		}
+		// Tail hit: plant in the final partial block.
+		copy(sparse[len(sparse)-len(pattern)-3:], pattern)
+
+		// Dense: the pattern repeated back-to-back (maximum overlap and
+		// candidate density; trips the kernel's adaptive bailout).
+		dense := bytes.Repeat([]byte(pattern), (32<<10)/len(pattern))
+
+		for name, input := range map[string][]byte{"sparse": sparse, "dense": dense} {
+			want := naiveMatch([]string{pattern}, input)
+			ms := tr.Match(input)
+			if d := diffTriples(triplesFromMatches(ms), want); d != -1 {
+				t.Fatalf("%q/%s: Match diverges from reference at %d", pattern, name, d)
+			}
+			tr.ReleaseMatches(ms)
+			if d := diffTriples(tr.triplesFromWalk(input), want); d != -1 {
+				t.Fatalf("%q/%s: Walk diverges from reference at %d", pattern, name, d)
+			}
+		}
+	}
+}

--- a/singlepattern_test.go
+++ b/singlepattern_test.go
@@ -285,6 +285,47 @@ func TestSingleLargeInputs(t *testing.T) {
 	}
 }
 
+// TestSingleLongDistanceFilter drives the kernel paths with a pattern
+// whose two selected filter bytes sit more than one 32-byte block apart,
+// so the kernel's second-byte load crosses into a later block than the
+// first: candidate mapping, the per-call read bound, and the scalar tail
+// all see d > 32 through Trie-derived offsets (the direct kernel test
+// stops at d == 32 and bypasses the builder's offset selection).
+func TestSingleLongDistanceFilter(t *testing.T) {
+	// '7' (digit, rank 80) and 'Q' (uppercase, rank 85) are the two
+	// rarest bytes; every middle byte is a common lowercase letter.
+	pattern := "Q" + strings.Repeat("eta", 13) + "7"
+	tr := NewTrieBuilder().AddString(pattern).Build()
+	if tr.single == nil {
+		t.Fatal("single not detected")
+	}
+	if d := absInt(tr.singleO1 - tr.singleO2); d <= 32 {
+		t.Fatalf("filter distance %d, want > 32; offsets %d,%d",
+			d, tr.singleO1, tr.singleO2)
+	}
+
+	input := bytes.Repeat([]byte("loremipsu"), 1000) // 9KB, no 'Q'/'7'
+	// Full-block hits, including adjacent occurrences.
+	copy(input[100:], pattern)
+	copy(input[100+len(pattern):], pattern)
+	copy(input[4096:], pattern)
+	// Scalar-tail hit: the last valid start, past the final full block.
+	copy(input[len(input)-len(pattern):], pattern)
+
+	want := naiveMatch([]string{pattern}, input)
+	if len(want) != 4 {
+		t.Fatalf("reference found %d occurrences, want 4", len(want))
+	}
+	ms := tr.Match(input)
+	if d := diffTriples(triplesFromMatches(ms), want); d != -1 {
+		t.Fatalf("Match diverges from reference at %d", d)
+	}
+	tr.ReleaseMatches(ms)
+	if d := diffTriples(tr.triplesFromWalk(input), want); d != -1 {
+		t.Fatalf("Walk diverges from reference at %d", d)
+	}
+}
+
 // TestSinglePatternRejectsNoncanonicalTable corrupts individual
 // transition entries of canonical single-pattern tables and asserts the
 // detector turns the fast path off: the shape checks (state count, one

--- a/trie.go
+++ b/trie.go
@@ -535,6 +535,21 @@ func (tr *Trie) skipRootTable(input []byte, i int) int {
 // skipRootIndex finds the next stop byte at or after i with one
 // bytes.IndexByte pass per stop value over successive 4KB windows.
 func (tr *Trie) skipRootIndex(input []byte, i int) int {
+	// With exactly two stop bytes and the vector kernel available, one
+	// single-pass scan replaces the windowed per-value passes entirely.
+	if hasOr2Kernel && len(tr.skipBytes) == 2 && i < len(input) {
+		a, b := tr.skipBytes[0], tr.skipBytes[1]
+		m := len(input) - i
+		if j := indexOr2(input[i:], m, a, b); j >= 0 {
+			return i + j
+		}
+		for t := i + m&^31; t < len(input); t++ {
+			if input[t] == a || input[t] == b {
+				return t
+			}
+		}
+		return len(input)
+	}
 	const window = 4096
 	inputLen := len(input)
 	for i < inputLen {


### PR DESCRIPTION
Two Plan 9 asm kernels following the internal/bytealg syndrome idiom (32 bytes/iteration, cheap VORR+VADDP existence check in the hot loop, positional syndrome only after a hit, RBIT+CLZ locate):

- **indexPair2**: first position with byte a at i and byte b at i+d — the memmem-style packed-pair candidate filter for the single-pattern paths (**24.5GB/s** on Graviton3 vs 4.4GB/s for the SWAR pair scan).
- **indexOr2**: first position of either of two byte values — a one-pass memchr2 for the two-stop-byte root skip (**26.6GB/s** vs two windowed IndexByte passes).

Dispatch is per kernel (`hasPairKernel`, `hasOr2Kernel`) because break-even is against arch-specific stdlib baselines, not a constant; non-arm64 builds and `-tags purego` keep the portable strategies via dead-code-eliminated dispatch.

**Safety**: both kernels process only full 32-byte blocks and never read past the caller-proven region; Go callers finish tails scalar. A guard-page test (buffer ending flush against PROT_NONE) proves the read contracts; exhaustive + randomized differentials cover every size/boundary/distance combination; go vet asmdecl checks the frame layout. The kernel searcher hands over mid-stream to the resumable SWAR scan when the candidate stream turns dense (>1/64 bytes after a 32-candidate grace), bounding restart-cost regret.

**Measured** (Graviton3, n=8, cpu=1): MatchFirstLate **-77%** (5.19us — parity with Rust's NEON memmem), Anchor **-53%** (5.5us, 21% ahead of Rust), Skip2 no-match **-19%** (parity with memchr2). Guard rows unchanged.

Part 5/6.