### PR TITLE
perf: SSE2 search kernels for the pair filter (amd64)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         # ubuntu-24.04-arm assembles index_arm64.s and runs the NEON
         # kernel differential and guard-page tests natively; ubuntu-24.04
-        # covers the portable paths on amd64.
+        # does the same for the SSE2 kernels in index_amd64.s.
         os: [ubuntu-24.04, ubuntu-24.04-arm]
     runs-on: ${{ matrix.os }}
     steps:
@@ -39,4 +39,11 @@ jobs:
           for goos in darwin windows freebsd netbsd openbsd; do
             echo "vet GOOS=$goos GOARCH=arm64"
             GOOS=$goos GOARCH=arm64 go vet ./...
+          done
+      - name: cross-compile vet for other amd64 targets
+        if: matrix.os == 'ubuntu-24.04'
+        run: |
+          for goos in darwin windows freebsd netbsd openbsd; do
+            echo "vet GOOS=$goos GOARCH=amd64"
+            GOOS=$goos GOARCH=amd64 go vet ./...
           done

--- a/index_amd64.go
+++ b/index_amd64.go
@@ -1,0 +1,38 @@
+//go:build amd64 && !purego
+
+package ahocorasick
+
+// Per-kernel availability constants: call sites branch on these, so
+// unused strategies compile away. The pair kernel wins on amd64; the
+// or2 kernel is compiled and tested but not dispatched, because the
+// stdlib IndexByte runs AVX2 here and two windowed 80GB/s passes beat
+// one 28GB/s SSE2 pass (measured on Zen 4: 39 vs 25GB/s effective on
+// the two-stop-byte no-match row). Enabling or2 on amd64 needs an
+// AVX2 kernel with runtime feature detection.
+const (
+	hasPairKernel = true
+	hasOr2Kernel  = false
+)
+
+// indexPair2Asm returns the smallest i in [0, m&^31) with p[i] == a and
+// p[i+d] == b, or -1 when the full 32-byte blocks contain no such
+// position (the caller scans the remaining tail with scalar code).
+// The caller must guarantee p[0 : m&^31 + d] is readable.
+//
+//go:noescape
+func indexPair2Asm(p *byte, m int, a, b byte, d int) int
+
+// indexOr2Asm returns the smallest i in [0, m&^31) with p[i] == a or
+// p[i] == b, or -1 when the full blocks contain neither value. Reads
+// p[0 : m&^31] only.
+//
+//go:noescape
+func indexOr2Asm(p *byte, m int, a, b byte) int
+
+func indexPair2(p []byte, m int, a, b byte, d int) int {
+	return indexPair2Asm(&p[0], m, a, b, d)
+}
+
+func indexOr2(p []byte, m int, a, b byte) int {
+	return indexOr2Asm(&p[0], m, a, b)
+}

--- a/index_amd64.go
+++ b/index_amd64.go
@@ -7,11 +7,14 @@ package ahocorasick
 // or2 kernel is compiled and tested but not dispatched, because the
 // stdlib IndexByte runs AVX2 here and two windowed 80GB/s passes beat
 // one 28GB/s SSE2 pass (measured on Zen 4: 39 vs 25GB/s effective on
-// the two-stop-byte no-match row). Enabling or2 on amd64 needs an
-// AVX2 kernel with runtime feature detection.
+// the two-stop-byte no-match row).
 const (
 	hasPairKernel = true
-	hasOr2Kernel  = false
+	// DO NOT flip to true while indexOr2 wraps the SSE2 kernel below:
+	// dispatching it measured a 57% regression on the two-stop-byte
+	// no-match row vs the windowed IndexByte path. Enabling or2 on
+	// amd64 requires an AVX2 kernel with runtime feature detection.
+	hasOr2Kernel = false
 )
 
 // indexPair2Asm returns the smallest i in [0, m&^31) with p[i] == a and

--- a/index_amd64.s
+++ b/index_amd64.s
@@ -1,0 +1,133 @@
+// SSE2 search kernels: the amd64 counterpart of index_arm64.s, same
+// contracts. 32 input bytes per iteration via two 16-byte compares;
+// PMOVMSKB folds each compare into a 16-bit mask (one bit per byte, in
+// input order), so a combined 32-bit mask plus BSF locates the first
+// hit exactly. SSE2 only — available on every amd64 CPU, no feature
+// detection needed.
+//
+// Neither kernel reads past its caller-proven region: both process only
+// full 32-byte blocks and report "no hit in the full blocks" with -1;
+// the Go callers finish the < 32-byte tail with scalar code.
+
+//go:build !purego
+
+#include "textflag.h"
+
+// func indexPair2Asm(p *byte, m int, a byte, b byte, d int) int
+//
+// Returns the smallest i in [0, m&^31) with p[i] == a && p[i+d] == b,
+// or -1 if there is none. The caller guarantees p[0 : m&^31 + d] is
+// readable (stream B reads p[d : d+(m&^31)]).
+TEXT ·indexPair2Asm(SB), NOSPLIT, $0-40
+	MOVQ	p+0(FP), SI
+	MOVQ	m+8(FP), CX
+	MOVBLZX	a+16(FP), AX
+	MOVBLZX	b+17(FP), BX
+	MOVQ	d+24(FP), DX
+	LEAQ	(SI)(DX*1), DI  // stream B cursor = p + d
+
+	// Broadcast a into X0, b into X1 (bytealg idiom).
+	MOVD	AX, X0
+	PUNPCKLBW	X0, X0
+	PUNPCKLBW	X0, X0
+	PSHUFL	$0, X0, X0
+	MOVD	BX, X1
+	PUNPCKLBW	X1, X1
+	PUNPCKLBW	X1, X1
+	PSHUFL	$0, X1, X1
+
+	XORQ	R10, R10        // positions consumed
+
+loop:
+	MOVQ	CX, R9
+	SUBQ	R10, R9         // remaining positions
+	CMPQ	R9, $32
+	JLT	notfound
+	MOVOU	(SI), X2
+	MOVOU	16(SI), X3
+	MOVOU	(DI), X4
+	MOVOU	16(DI), X5
+	PCMPEQB	X0, X2          // stream A == a, bytes 0-15
+	PCMPEQB	X0, X3          // bytes 16-31
+	PCMPEQB	X1, X4          // stream B == b, bytes 0-15
+	PCMPEQB	X1, X5          // bytes 16-31
+	PAND	X4, X2          // pair condition
+	PAND	X5, X3
+	PMOVMSKB	X2, R11
+	PMOVMSKB	X3, R12
+	SHLL	$16, R12
+	ORL	R12, R11        // 32-bit mask, one bit per position
+	TESTL	R11, R11
+	JNZ	found
+	ADDQ	$32, SI
+	ADDQ	$32, DI
+	ADDQ	$32, R10
+	JMP	loop
+
+found:
+	BSFL	R11, R11
+	LEAQ	(R10)(R11*1), AX
+	MOVQ	AX, ret+32(FP)
+	RET
+
+notfound:
+	MOVQ	$-1, AX
+	MOVQ	AX, ret+32(FP)
+	RET
+
+// func indexOr2Asm(p *byte, m int, a byte, b byte) int
+//
+// Returns the smallest i in [0, m&^31) with p[i] == a || p[i] == b, or
+// -1 if there is none. Reads p[0 : m&^31] only.
+TEXT ·indexOr2Asm(SB), NOSPLIT, $0-32
+	MOVQ	p+0(FP), SI
+	MOVQ	m+8(FP), CX
+	MOVBLZX	a+16(FP), AX
+	MOVBLZX	b+17(FP), BX
+
+	MOVD	AX, X0
+	PUNPCKLBW	X0, X0
+	PUNPCKLBW	X0, X0
+	PSHUFL	$0, X0, X0
+	MOVD	BX, X1
+	PUNPCKLBW	X1, X1
+	PUNPCKLBW	X1, X1
+	PSHUFL	$0, X1, X1
+
+	XORQ	R10, R10
+
+loop:
+	MOVQ	CX, R9
+	SUBQ	R10, R9
+	CMPQ	R9, $32
+	JLT	notfound
+	MOVOU	(SI), X2
+	MOVOU	16(SI), X3
+	MOVOA	X2, X4
+	MOVOA	X3, X5
+	PCMPEQB	X0, X2          // == a
+	PCMPEQB	X0, X3
+	PCMPEQB	X1, X4          // == b
+	PCMPEQB	X1, X5
+	POR	X4, X2          // either value
+	POR	X5, X3
+	PMOVMSKB	X2, R11
+	PMOVMSKB	X3, R12
+	SHLL	$16, R12
+	ORL	R12, R11
+	TESTL	R11, R11
+	JNZ	found
+	ADDQ	$32, SI
+	ADDQ	$32, R10
+	JMP	loop
+
+found:
+	BSFL	R11, R11
+	LEAQ	(R10)(R11*1), AX
+	MOVQ	AX, ret+24(FP)
+	RET
+
+notfound:
+	MOVQ	$-1, AX
+	MOVQ	AX, ret+24(FP)
+	RET

--- a/index_generic.go
+++ b/index_generic.go
@@ -1,4 +1,4 @@
-//go:build !arm64 || purego
+//go:build (!arm64 && !amd64) || purego
 
 package ahocorasick
 

--- a/index_kernel_bench_test.go
+++ b/index_kernel_bench_test.go
@@ -1,4 +1,4 @@
-//go:build arm64 && !purego
+//go:build (arm64 || amd64) && !purego
 
 package ahocorasick
 

--- a/index_kernel_test.go
+++ b/index_kernel_test.go
@@ -1,4 +1,4 @@
-//go:build arm64 && !purego
+//go:build (arm64 || amd64) && !purego
 
 package ahocorasick
 

--- a/index_kernel_unix_test.go
+++ b/index_kernel_unix_test.go
@@ -1,4 +1,4 @@
-//go:build arm64 && !purego && unix
+//go:build (arm64 || amd64) && !purego && unix
 
 package ahocorasick
 


### PR DESCRIPTION
The amd64 counterpart of the NEON kernels behind the same two-function seam: two 16-byte PCMPEQB compares per iteration, PMOVMSKB folds each into a per-byte mask, BSF on the combined 32-bit mask locates the first hit. SSE2 only — no runtime feature detection.

Only the pair kernel dispatches (`hasPairKernel`). The or2 kernel is compiled and tested but held back (`hasOr2Kernel=false`): stdlib IndexByte runs AVX2 on amd64, and two windowed ~80GB/s passes beat one 28GB/s SSE2 pass — **measured +57% regression** on the Skip2 no-match row when dispatched, vs -1% with the windowed path kept. An AVX2 or2 variant with feature detection can flip the constant.

Kernel tests (exhaustive differential, randomized differential, guard-page overread proof) now gate both ISAs.

**Measured** (Zen 4 EPYC 9R14, n=6, cpu=1, vs portable strategies): MatchFirstLate **-85%** (3.75us, 29.4GB/s), Anchor **-39%** (4.09us); guard rows unchanged; full suite + race + purego + fuzz green on both arches.

Part 6/6.