### PR TITLE
perf: scale chainSample's budget down at chunk size

### DIFF
--- a/dualscan_test.go
+++ b/dualscan_test.go
@@ -16,11 +16,11 @@ import (
 // buildStopByte16Trie builds a trie for patterns and asserts it takes the
 // 16-bit single-stop-byte path that scanRange16 and matchDualStopByte16
 // require.
-func buildStopByte16Trie(t *testing.T, patterns []string) *Trie {
-	t.Helper()
+func buildStopByte16Trie(tb testing.TB, patterns []string) *Trie {
+	tb.Helper()
 	tr := NewTrieBuilder().AddStrings(patterns).Build()
 	if tr.failTrans16 == nil || len(tr.rootStopBytes) != 1 {
-		t.Fatalf("test setup: trie must take the 16-bit single-stop-byte path (failTrans16=%v, stop bytes=%d)",
+		tb.Fatalf("test setup: trie must take the 16-bit single-stop-byte path (failTrans16=%v, stop bytes=%d)",
 			tr.failTrans16 != nil, len(tr.rootStopBytes))
 	}
 	return tr

--- a/routingpreserve_test.go
+++ b/routingpreserve_test.go
@@ -1,0 +1,86 @@
+package ahocorasick
+
+// routingpreserve_test.go - tripwire for the dual-vs-single routing
+// verdict. chainSample's budget scales with input size
+// (chainSampleSmallMax), so this asserts the ROUTING VERDICT (not the
+// raw votes) on the corpus shapes whose routing the calibration
+// constants promise, at sizes on both sides of the budget threshold. A
+// sampling change that flips one of these mis-routes a scan family:
+// word-like dense input loses the dual-cursor win, or shallow-chain
+// dense input loses the single-cursor win (measured 1.4x on that
+// shape).
+
+import (
+	"os"
+	"testing"
+)
+
+func TestRoutingPreserved(t *testing.T) {
+	patterns, err := readPatterns("./test_data/NSF-ordlisten.cleaned.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ibsen := mustRead(t, "./test_data/Ibsen.txt")
+	tr := NewTrieBuilder().AddStrings(patterns[:10000]).Build()
+
+	var wordlike []byte
+	for i := 0; len(wordlike) < 256<<10; i++ {
+		wordlike = append(wordlike, patterns[i%10000]...)
+	}
+	fs := spFalseStartCorpus(tr.rootStopBytes[0], 256<<10)
+
+	// Routing the calibration constants promise; must hold at both
+	// sampling budgets (below and at-or-above chainSampleSmallMax).
+	for _, c := range []struct {
+		name  string
+		input []byte
+		want  bool
+	}{
+		// Long-chain dense input routes dual at every scale, chunk or whole.
+		{"wordlike-12k", wordlike[:12<<10], true},
+		{"wordlike-16k", wordlike[:16<<10], true},
+		{"wordlike-32k", wordlike[:32<<10], true},
+		{"wordlike-96k", wordlike[:96<<10], true},
+		// Depth-1 excursions route single despite maximal density.
+		{"falsestart-12k", fs[:12<<10], false},
+		{"falsestart-16k", fs[:16<<10], false},
+		{"falsestart-96k", fs[:96<<10], false},
+		// Natural text (short chains, sparse-ish) routes single.
+		{"ibsen-12k", ibsen[:12<<10], false},
+		{"ibsen-48k", ibsen[:48<<10], false},
+		{"ibsen-96k", ibsen[:96<<10], false},
+	} {
+		if got := tr.dualWorthwhile(c.input); got != c.want {
+			t.Errorf("%s: dualWorthwhile=%v, want %v (routing flipped)", c.name, got, c.want)
+		}
+	}
+
+	// Characterization only: separator-broken corpora sit near the vote
+	// thresholds, so their verdicts are logged rather than asserted;
+	// compare against BenchmarkSPGray when a flip appears.
+	for _, gap := range []int{2, 4, 8} {
+		var sb []byte
+		i := 0
+		for len(sb) < 96<<10 {
+			sb = append(sb, patterns[i%10000]...)
+			for g := 0; g < gap; g++ {
+				sb = append(sb, 'x')
+			}
+			i++
+		}
+		for _, size := range []int{12 << 10, 96 << 10} {
+			t.Logf("gray gap%d %dKiB: dualWorthwhile=%v",
+				gap, size>>10, tr.dualWorthwhile(sb[:size]))
+		}
+	}
+
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
+}

--- a/routingpreserve_test.go
+++ b/routingpreserve_test.go
@@ -11,7 +11,6 @@ package ahocorasick
 // shape).
 
 import (
-	"os"
 	"testing"
 )
 
@@ -20,13 +19,13 @@ func TestRoutingPreserved(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ibsen := mustRead(t, "./test_data/Ibsen.txt")
-	tr := NewTrieBuilder().AddStrings(patterns[:10000]).Build()
-
-	var wordlike []byte
-	for i := 0; len(wordlike) < 256<<10; i++ {
-		wordlike = append(wordlike, patterns[i%10000]...)
+	ibsen := benchReadFile(t, "./test_data/Ibsen.txt")
+	if len(ibsen) < 96<<10 {
+		t.Fatalf("Ibsen.txt fixture too short: %d bytes, need %d", len(ibsen), 96<<10)
 	}
+	tr := buildStopByte16Trie(t, patterns[:10000])
+
+	wordlike := concat(patterns[:10000], 256<<10)
 	fs := spFalseStartCorpus(tr.rootStopBytes[0], 256<<10)
 
 	// Routing the calibration constants promise; must hold at both
@@ -74,13 +73,4 @@ func TestRoutingPreserved(t *testing.T) {
 		}
 	}
 
-}
-
-func mustRead(t *testing.T, path string) []byte {
-	t.Helper()
-	b, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return b
 }

--- a/samplepolicy_bench_test.go
+++ b/samplepolicy_bench_test.go
@@ -25,7 +25,16 @@ import (
 
 // spTrie builds the single-stop-byte 16-bit automaton (sorted10k: first
 // 10k NSF words) and asserts the automaton shape the experiment needs.
+// It also gates the file on the 8-proc worker complement the rows'
+// chunk geometry was designed around: at GOMAXPROCS below 8 the
+// dispatcher hands out fewer, larger chunks (e.g. 96KiB across 4
+// workers is 24KiB chunks), which take the full sampling budget under
+// row names that promise the reduced one, so constrained runners skip
+// loudly instead of reporting numbers for the wrong policy regime.
 func spTrie(b *testing.B) *Trie {
+	if procs := runtime.GOMAXPROCS(0); procs < 8 {
+		b.Skipf("SP rows pin 8-worker chunk geometry; GOMAXPROCS=%d would time larger full-budget chunks under reduced-budget row names", procs)
+	}
 	patterns, _ := labLoad(b)
 	tr := buildStopByte16Trie(b, patterns[:10000])
 	if tr.single != nil {
@@ -42,10 +51,11 @@ func spDenseCorpus(b *testing.B) []byte {
 }
 
 // assertRegime pins the dispatch decision the experiment depends on,
-// evaluated at the same GOMAXPROCS Match's own dispatch uses, so a
-// constrained runner (e.g. -cpu=1) fails loudly here instead of
-// silently measuring the wrong path. Passing resets the timer so the
-// assertion's sampling cost stays out of short benchtime runs.
+// evaluated at the same GOMAXPROCS Match's own dispatch uses (spTrie
+// has already gated the file on >= 8 procs, so a parallel regime here
+// implies the intended 8-worker chunk geometry, not a degenerate 2-4
+// worker split). Passing resets the timer so the assertion's sampling
+// cost stays out of short benchtime runs.
 func assertRegime(b *testing.B, tr *Trie, input []byte, wantParallel, wantDense, wantKnown bool) {
 	b.Helper()
 	procs := runtime.GOMAXPROCS(0)

--- a/samplepolicy_bench_test.go
+++ b/samplepolicy_bench_test.go
@@ -1,0 +1,320 @@
+package ahocorasick
+
+// samplepolicy_bench_test.go - benchmark matrix for the sampling-based
+// dispatch and routing gates of the single-stop-byte 16-bit family:
+// looksDense at the parallel gate, the per-chunk dual-vs-single routing
+// inside matchParallel workers, and chainSample's size-scaled budget.
+//
+// The gate-sampled parallel band is narrow. It requires, simultaneously:
+//   - a multi-pattern, single-stop-byte automaton with 16-bit rows,
+//   - input length in [parallelMin, parallelSparseMin) = [32 KiB, 128 KiB),
+//   - a dense whole-input verdict from looksDense (>= ~10% stop bytes).
+// Only then does Match take the parallel branch with a sampled verdict;
+// workers then route chunk-locally (density below the chain floor, chain
+// vote with a density tie-break above it).
+//
+// Every benchmark asserts its dispatch regime in setup so a benchmark
+// cannot silently measure the wrong path.
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+// spTrie builds the single-stop-byte 16-bit automaton (sorted10k: first
+// 10k NSF words) and asserts the automaton shape the experiment needs.
+func spTrie(b *testing.B) *Trie {
+	patterns, _ := labLoad(b)
+	tr := NewTrieBuilder().AddStrings(patterns[:10000]).Build()
+	if tr.failTrans16 == nil || len(tr.rootStopBytes) != 1 || tr.single != nil {
+		b.Fatalf("want single-stop-byte 16-bit automaton, got ft16=%v stops=%d single=%v",
+			tr.failTrans16 != nil, len(tr.rootStopBytes), tr.single != nil)
+	}
+	return tr
+}
+
+// spDenseCorpus returns >=256KiB of concatenated dictionary words: the
+// stop-byte-dense, excursion-heavy regime (measured ~11-15% density).
+func spDenseCorpus(b *testing.B, tr *Trie) []byte {
+	patterns, _ := labLoad(b)
+	var sb []byte
+	i := 0
+	for len(sb) < 256<<10 {
+		sb = append(sb, patterns[i%10000]...)
+		i++
+	}
+	return sb
+}
+
+// spSparseFiller returns n bytes containing no stop bytes (digit noise),
+// scanned via the vectorized root skip at full speed.
+func spSparseFiller(n int) []byte {
+	out := make([]byte, n)
+	// Deterministic digit filler; no stop byte of the sorted10k automaton
+	// ('a'..'z' words) appears in '0'..'9'.
+	x := uint64(0x9E3779B97F4A7C15)
+	for i := range out {
+		x ^= x << 13
+		x ^= x >> 7
+		x ^= x << 17
+		out[i] = byte('0' + x%10)
+	}
+	return out
+}
+
+// assertRegime pins the dispatch decision the experiment depends on.
+func assertRegime(b *testing.B, tr *Trie, input []byte, wantParallel, wantDense, wantKnown bool) {
+	b.Helper()
+	p, dense, known := tr.parallelWorkersDense(input, 64)
+	if (p > 0) != wantParallel || dense != wantDense || known != wantKnown {
+		density := float64(bytes.Count(input, []byte{tr.rootStopBytes[0]})) / float64(len(input))
+		b.Fatalf("regime mismatch at %dKiB (density %.3f): got p=%d dense=%v known=%v, want parallel=%v dense=%v known=%v",
+			len(input)>>10, density, p, dense, known, wantParallel, wantDense, wantKnown)
+	}
+}
+
+// --- Affected band: homogeneous dense input, dispatch path ---------------
+//
+// Sizes chosen to straddle the chunk-size chain floor
+// (dualChainFloor*(maxLen+1024)): at 32-64 KiB chunks are ~8 KiB and each
+// worker pays a chunk-local looksDense; at 96-127 KiB chunks are 12-16 KiB
+// and workers chain-vote instead (density only breaks ties). 127 KiB stays
+// under parallelSparseMin, past which the gate stops sampling entirely.
+func BenchmarkSPDenseBand(b *testing.B) {
+	tr := spTrie(b)
+	corpus := spDenseCorpus(b, tr)
+	for _, size := range []int{32 << 10, 48 << 10, 64 << 10, 96 << 10, 127 << 10} {
+		input := corpus[:size]
+		b.Run(fmt.Sprintf("%dk", size>>10), func(b *testing.B) {
+			assertRegime(b, tr, input, true, true, true)
+			benchMatch(b, tr, input)
+		})
+	}
+}
+
+// --- Mis-routing probe: heterogeneous input, dense whole-input verdict ---
+//
+// Dense (concatenated words) blocks with sparse (digit) blocks placed
+// BETWEEN the head/mid/tail windows looksDense samples, so the gate's
+// whole-input verdict is dense while individual 8 KiB worker chunks are
+// locally sparse - the pocket a whole-input sample structurally misses.
+// A worker whose chunk lands in a digit run samples locally and routes
+// to the single-cursor scan; these rows guard that chunk-local routing.
+func spHeteroInput(b *testing.B, tr *Trie, size int, sparseBlocks map[int]bool) []byte {
+	dense := spDenseCorpus(b, tr)
+	sparse := spSparseFiller(size)
+	out := make([]byte, 0, size)
+	const block = 8 << 10
+	for i := 0; len(out) < size; i++ {
+		src := dense
+		if sparseBlocks[i] {
+			src = sparse
+		}
+		off := (i * block) % (len(src) - block)
+		out = append(out, src[off:off+block]...)
+	}
+	return out[:size]
+}
+
+func BenchmarkSPHetero(b *testing.B) {
+	tr := spTrie(b)
+	// 64 KiB = 8 blocks of 8 KiB; looksDense windows land in blocks
+	// 0 (head), 4 (mid), 7 (tail); workers get one block each (p=8).
+	// 96 KiB = 12 blocks; windows land in blocks 0, 6, 11; p=8 gives
+	// 12 KiB chunks, each spanning 1.5 blocks.
+	for _, cfg := range []struct {
+		name   string
+		size   int
+		sparse map[int]bool
+	}{
+		// Half the chunks locally sparse - maximal mis-routing exposure.
+		{"64k-half-sparse", 64 << 10, map[int]bool{1: true, 2: true, 5: true, 6: true}},
+		// A quarter sparse - the milder pocket.
+		{"64k-quarter-sparse", 64 << 10, map[int]bool{2: true, 5: true}},
+		{"96k-third-sparse", 96 << 10, map[int]bool{1: true, 3: true, 8: true, 9: true}},
+	} {
+		input := spHeteroInput(b, tr, cfg.size, cfg.sparse)
+		b.Run(cfg.name, func(b *testing.B) {
+			assertRegime(b, tr, input, true, true, true)
+			benchMatch(b, tr, input)
+		})
+	}
+}
+
+// --- Controls: paths the policy change must NOT touch --------------------
+
+// Sparse verdict in the sampled band: sequential fallback, verdict already
+// threaded to matchSeq by PR #32. Identical in all variants.
+func BenchmarkSPSparseSeqControl(b *testing.B) {
+	tr := spTrie(b)
+	_, ibsen := labLoad(b)
+	for _, size := range []int{48 << 10, 96 << 10} {
+		input := ibsen[:size]
+		b.Run(fmt.Sprintf("ibsen-%dk", size>>10), func(b *testing.B) {
+			assertRegime(b, tr, input, false, false, true)
+			benchMatch(b, tr, input)
+		})
+	}
+}
+
+// Past parallelSparseMin the gate never samples (denseKnown=false), so
+// workers must keep routing locally in every variant. Guards against the
+// plumbing regressing the unsampled large-input path.
+func BenchmarkSPLargeControl(b *testing.B) {
+	tr := spTrie(b)
+	corpus := spDenseCorpus(b, tr)
+	_, ibsen := labLoad(b)
+	big := make([]byte, 0, 1<<20)
+	for len(big) < 1<<20 {
+		big = append(big, ibsen...)
+	}
+	for _, c := range []struct {
+		name  string
+		input []byte
+	}{
+		{"dense-256k", corpus[:256<<10]},
+		{"ibsen-512k", big[:512<<10]},
+	} {
+		b.Run(c.name, func(b *testing.B) {
+			assertRegime(b, tr, c.input, true, false, false)
+			benchMatch(b, tr, c.input)
+		})
+	}
+}
+
+// --- Cost floor: what is a density sample worth at all? ------------------
+//
+// Direct measurement of looksDense on an 8 KiB chunk (three vectorized
+// 1 KiB bytes.Count windows). The wall-clock ceiling of the entire
+// optimization is roughly ONE of these (workers sample concurrently), so
+// this number bounds the best case before any benchmark runs.
+func BenchmarkSPLooksDenseCost(b *testing.B) {
+	tr := spTrie(b)
+	corpus := spDenseCorpus(b, tr)
+	chunk := corpus[:8<<10]
+	c := tr.rootStopBytes[0]
+	b.SetBytes(int64(len(chunk)))
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		if !looksDense(chunk, c) {
+			b.Fatal("expected dense chunk")
+		}
+	}
+}
+
+// --- Routing-divergence probe: false-start input --------------------------
+//
+// Stop byte on every other position, but excursions die at depth 1 (a
+// digit never continues any pattern). Density says dense (~50%), so the
+// gate dispatches parallel with a dense verdict; above the chain floor
+// (96k+, 12-16 KiB chunks) each worker's chain vote says SHORT and
+// routes the single-cursor scan, measured 1.4x faster on this shape
+// (see dualChainShortMax). Density alone would mis-route every chunk
+// dual - these rows guard the chain vote's override. At 64k (8 KiB
+// chunks, below the chain floor) routing falls back to density, so that
+// row covers the density-routed shape of the same input.
+func BenchmarkSPFalseStart(b *testing.B) {
+	tr := spTrie(b)
+	corpus := spFalseStartCorpus(tr.rootStopBytes[0], 127<<10)
+	for _, size := range []int{64 << 10, 96 << 10, 127 << 10} {
+		input := corpus[:size]
+		b.Run(fmt.Sprintf("%dk", size>>10), func(b *testing.B) {
+			assertRegime(b, tr, input, true, true, true)
+			benchMatch(b, tr, input)
+		})
+	}
+}
+
+// --- Sequential small band: chainSample also runs here -------------------
+//
+// Inputs in [dualChainFloor*(maxLen+1024) ~10.5k, parallelMin 32k) stay
+// sequential and chain-sample the whole input. A chunk-scale sampling
+// budget change (len < 16 KiB) affects the 12k row and not the 24k row.
+func BenchmarkSPSeqSmall(b *testing.B) {
+	tr := spTrie(b)
+	corpus := spDenseCorpus(b, tr)
+	fs := spFalseStartCorpus(tr.rootStopBytes[0], 32<<10)
+	for _, c := range []struct {
+		name  string
+		input []byte
+	}{
+		{"dense-12k", corpus[:12<<10]},
+		{"dense-24k", corpus[:24<<10]},
+		{"falsestart-12k", fs[:12<<10]},
+	} {
+		b.Run(c.name, func(b *testing.B) {
+			assertRegime(b, tr, c.input, false, false, false)
+			benchMatch(b, tr, c.input)
+		})
+	}
+}
+
+// --- Gray zone: separator-broken chains, dense verdict -------------------
+//
+// Words separated by short 'x' runs: stop-byte density stays above the
+// gate's dense bar but separators cut excursions short, so the chain
+// vote sits in the gray band where sampling-budget changes could flip
+// windows. gap picked at setup so the whole input still gates dense.
+func BenchmarkSPGray(b *testing.B) {
+	patterns, _ := labLoad(b)
+	tr := spTrie(b)
+	for _, gap := range []int{2, 3} {
+		var sb []byte
+		i := 0
+		for len(sb) < 127<<10 {
+			sb = append(sb, patterns[i%10000]...)
+			for g := 0; g < gap; g++ {
+				sb = append(sb, 'x')
+			}
+			i++
+		}
+		input := sb[:96<<10]
+		b.Run(fmt.Sprintf("gap%d-96k", gap), func(b *testing.B) {
+			assertRegime(b, tr, input, true, true, true)
+			benchMatch(b, tr, input)
+		})
+	}
+}
+
+// spFalseStartCorpus returns n bytes alternating the stop byte with
+// digits: maximal stop-byte density with excursions that die at depth 1.
+func spFalseStartCorpus(c byte, n int) []byte {
+	out := make([]byte, n)
+	for i := range out {
+		if i%2 == 0 {
+			out[i] = c
+		} else {
+			out[i] = byte('0' + (i/2)%10)
+		}
+	}
+	return out
+}
+
+// BenchmarkSPChainSampleCost times chainSample itself per corpus shape.
+// The 12k rows take the reduced small-input budget, the 16k+ rows the
+// full one; on the parallel dense band every worker pays the 12-16k cost
+// before scanning its chunk, so this bounds what chunk routing can cost.
+func BenchmarkSPChainSampleCost(b *testing.B) {
+	tr := spTrie(b)
+	corpus := spDenseCorpus(b, tr)
+	_, ibsen := labLoad(b)
+	falsestart := spFalseStartCorpus(tr.rootStopBytes[0], 96<<10)
+	for _, c := range []struct {
+		name string
+		data []byte
+	}{
+		{"wordlike-12k", corpus[:12<<10]},
+		{"wordlike-16k", corpus[:16<<10]},
+		{"wordlike-32k", corpus[:32<<10]},
+		{"falsestart-12k", falsestart[:12<<10]},
+		{"ibsen-12k", ibsen[:12<<10]},
+	} {
+		b.Run(c.name, func(b *testing.B) {
+			for n := 0; n < b.N; n++ {
+				long, short := tr.chainSample(c.data)
+				_ = long + short
+			}
+		})
+	}
+}

--- a/samplepolicy_bench_test.go
+++ b/samplepolicy_bench_test.go
@@ -13,12 +13,13 @@ package ahocorasick
 // workers then route chunk-locally (density below the chain floor, chain
 // vote with a density tie-break above it).
 //
-// Every benchmark asserts its dispatch regime in setup so a benchmark
-// cannot silently measure the wrong path.
+// Every benchmark asserts its dispatch regime before its timed loop (and
+// resets the timer) so a benchmark cannot silently measure the wrong path.
 
 import (
 	"bytes"
 	"fmt"
+	"runtime"
 	"testing"
 )
 
@@ -26,52 +27,35 @@ import (
 // 10k NSF words) and asserts the automaton shape the experiment needs.
 func spTrie(b *testing.B) *Trie {
 	patterns, _ := labLoad(b)
-	tr := NewTrieBuilder().AddStrings(patterns[:10000]).Build()
-	if tr.failTrans16 == nil || len(tr.rootStopBytes) != 1 || tr.single != nil {
-		b.Fatalf("want single-stop-byte 16-bit automaton, got ft16=%v stops=%d single=%v",
-			tr.failTrans16 != nil, len(tr.rootStopBytes), tr.single != nil)
+	tr := buildStopByte16Trie(b, patterns[:10000])
+	if tr.single != nil {
+		b.Fatal("want a multi-pattern automaton, got the single-pattern fast path")
 	}
 	return tr
 }
 
-// spDenseCorpus returns >=256KiB of concatenated dictionary words: the
+// spDenseCorpus returns 256KiB of concatenated dictionary words: the
 // stop-byte-dense, excursion-heavy regime (measured ~11-15% density).
-func spDenseCorpus(b *testing.B, tr *Trie) []byte {
+func spDenseCorpus(b *testing.B) []byte {
 	patterns, _ := labLoad(b)
-	var sb []byte
-	i := 0
-	for len(sb) < 256<<10 {
-		sb = append(sb, patterns[i%10000]...)
-		i++
-	}
-	return sb
+	return concat(patterns[:10000], 256<<10)
 }
 
-// spSparseFiller returns n bytes containing no stop bytes (digit noise),
-// scanned via the vectorized root skip at full speed.
-func spSparseFiller(n int) []byte {
-	out := make([]byte, n)
-	// Deterministic digit filler; no stop byte of the sorted10k automaton
-	// ('a'..'z' words) appears in '0'..'9'.
-	x := uint64(0x9E3779B97F4A7C15)
-	for i := range out {
-		x ^= x << 13
-		x ^= x >> 7
-		x ^= x << 17
-		out[i] = byte('0' + x%10)
-	}
-	return out
-}
-
-// assertRegime pins the dispatch decision the experiment depends on.
+// assertRegime pins the dispatch decision the experiment depends on,
+// evaluated at the same GOMAXPROCS Match's own dispatch uses, so a
+// constrained runner (e.g. -cpu=1) fails loudly here instead of
+// silently measuring the wrong path. Passing resets the timer so the
+// assertion's sampling cost stays out of short benchtime runs.
 func assertRegime(b *testing.B, tr *Trie, input []byte, wantParallel, wantDense, wantKnown bool) {
 	b.Helper()
-	p, dense, known := tr.parallelWorkersDense(input, 64)
+	procs := runtime.GOMAXPROCS(0)
+	p, dense, known := tr.parallelWorkersDense(input, procs)
 	if (p > 0) != wantParallel || dense != wantDense || known != wantKnown {
 		density := float64(bytes.Count(input, []byte{tr.rootStopBytes[0]})) / float64(len(input))
-		b.Fatalf("regime mismatch at %dKiB (density %.3f): got p=%d dense=%v known=%v, want parallel=%v dense=%v known=%v",
-			len(input)>>10, density, p, dense, known, wantParallel, wantDense, wantKnown)
+		b.Fatalf("regime mismatch at %dKiB (density %.3f, GOMAXPROCS %d): got p=%d dense=%v known=%v, want parallel=%v dense=%v known=%v",
+			len(input)>>10, density, procs, p, dense, known, wantParallel, wantDense, wantKnown)
 	}
+	b.ResetTimer()
 }
 
 // --- Affected band: homogeneous dense input, dispatch path ---------------
@@ -83,7 +67,7 @@ func assertRegime(b *testing.B, tr *Trie, input []byte, wantParallel, wantDense,
 // under parallelSparseMin, past which the gate stops sampling entirely.
 func BenchmarkSPDenseBand(b *testing.B) {
 	tr := spTrie(b)
-	corpus := spDenseCorpus(b, tr)
+	corpus := spDenseCorpus(b)
 	for _, size := range []int{32 << 10, 48 << 10, 64 << 10, 96 << 10, 127 << 10} {
 		input := corpus[:size]
 		b.Run(fmt.Sprintf("%dk", size>>10), func(b *testing.B) {
@@ -101,9 +85,12 @@ func BenchmarkSPDenseBand(b *testing.B) {
 // locally sparse - the pocket a whole-input sample structurally misses.
 // A worker whose chunk lands in a digit run samples locally and routes
 // to the single-cursor scan; these rows guard that chunk-local routing.
-func spHeteroInput(b *testing.B, tr *Trie, size int, sparseBlocks map[int]bool) []byte {
-	dense := spDenseCorpus(b, tr)
-	sparse := spSparseFiller(size)
+func spHeteroInput(b *testing.B, size int, sparseBlocks map[int]bool) []byte {
+	dense := spDenseCorpus(b)
+	// '0' filler: a digit never continues any pattern of the sorted10k
+	// ('a'..'z' words) automaton, so these blocks contain no stop bytes
+	// and scan via the vectorized root skip at full speed.
+	sparse := bytesFill(size, '0')
 	out := make([]byte, 0, size)
 	const block = 8 << 10
 	for i := 0; len(out) < size; i++ {
@@ -134,7 +121,7 @@ func BenchmarkSPHetero(b *testing.B) {
 		{"64k-quarter-sparse", 64 << 10, map[int]bool{2: true, 5: true}},
 		{"96k-third-sparse", 96 << 10, map[int]bool{1: true, 3: true, 8: true, 9: true}},
 	} {
-		input := spHeteroInput(b, tr, cfg.size, cfg.sparse)
+		input := spHeteroInput(b, cfg.size, cfg.sparse)
 		b.Run(cfg.name, func(b *testing.B) {
 			assertRegime(b, tr, input, true, true, true)
 			benchMatch(b, tr, input)
@@ -144,8 +131,9 @@ func BenchmarkSPHetero(b *testing.B) {
 
 // --- Controls: paths the policy change must NOT touch --------------------
 
-// Sparse verdict in the sampled band: sequential fallback, verdict already
-// threaded to matchSeq by PR #32. Identical in all variants.
+// Sparse verdict in the sampled band: the sequential fallback reuses the
+// gate's sampled verdict (threaded to matchSeq), so this control should
+// remain unchanged.
 func BenchmarkSPSparseSeqControl(b *testing.B) {
 	tr := spTrie(b)
 	_, ibsen := labLoad(b)
@@ -163,7 +151,7 @@ func BenchmarkSPSparseSeqControl(b *testing.B) {
 // plumbing regressing the unsampled large-input path.
 func BenchmarkSPLargeControl(b *testing.B) {
 	tr := spTrie(b)
-	corpus := spDenseCorpus(b, tr)
+	corpus := spDenseCorpus(b)
 	_, ibsen := labLoad(b)
 	big := make([]byte, 0, 1<<20)
 	for len(big) < 1<<20 {
@@ -191,7 +179,7 @@ func BenchmarkSPLargeControl(b *testing.B) {
 // this number bounds the best case before any benchmark runs.
 func BenchmarkSPLooksDenseCost(b *testing.B) {
 	tr := spTrie(b)
-	corpus := spDenseCorpus(b, tr)
+	corpus := spDenseCorpus(b)
 	chunk := corpus[:8<<10]
 	c := tr.rootStopBytes[0]
 	b.SetBytes(int64(len(chunk)))
@@ -233,7 +221,7 @@ func BenchmarkSPFalseStart(b *testing.B) {
 // budget change (len < 16 KiB) affects the 12k row and not the 24k row.
 func BenchmarkSPSeqSmall(b *testing.B) {
 	tr := spTrie(b)
-	corpus := spDenseCorpus(b, tr)
+	corpus := spDenseCorpus(b)
 	fs := spFalseStartCorpus(tr.rootStopBytes[0], 32<<10)
 	for _, c := range []struct {
 		name  string
@@ -293,11 +281,14 @@ func spFalseStartCorpus(c byte, n int) []byte {
 
 // BenchmarkSPChainSampleCost times chainSample itself per corpus shape.
 // The 12k rows take the reduced small-input budget, the 16k+ rows the
-// full one; on the parallel dense band every worker pays the 12-16k cost
-// before scanning its chunk, so this bounds what chunk routing can cost.
+// full one. This is the uncontended per-call cost - a floor, not a
+// bound on the parallel critical path: on a dense-verdict dispatch
+// every worker walks its sample concurrently, where the dependent
+// table loads run several-fold slower under shared-LLC contention
+// (~5x at 8 workers measured on Graviton3).
 func BenchmarkSPChainSampleCost(b *testing.B) {
 	tr := spTrie(b)
-	corpus := spDenseCorpus(b, tr)
+	corpus := spDenseCorpus(b)
 	_, ibsen := labLoad(b)
 	falsestart := spFalseStartCorpus(tr.rootStopBytes[0], 96<<10)
 	for _, c := range []struct {

--- a/samplepolicy_bench_test.go
+++ b/samplepolicy_bench_test.go
@@ -25,22 +25,27 @@ import (
 
 // spTrie builds the single-stop-byte 16-bit automaton (sorted10k: first
 // 10k NSF words) and asserts the automaton shape the experiment needs.
-// It also gates the file on the 8-proc worker complement the rows'
-// chunk geometry was designed around: at GOMAXPROCS below 8 the
-// dispatcher hands out fewer, larger chunks (e.g. 96KiB across 4
-// workers is 24KiB chunks), which take the full sampling budget under
-// row names that promise the reduced one, so constrained runners skip
-// loudly instead of reporting numbers for the wrong policy regime.
 func spTrie(b *testing.B) *Trie {
-	if procs := runtime.GOMAXPROCS(0); procs < 8 {
-		b.Skipf("SP rows pin 8-worker chunk geometry; GOMAXPROCS=%d would time larger full-budget chunks under reduced-budget row names", procs)
-	}
 	patterns, _ := labLoad(b)
 	tr := buildStopByte16Trie(b, patterns[:10000])
 	if tr.single != nil {
 		b.Fatal("want a multi-pattern automaton, got the single-pattern fast path")
 	}
 	return tr
+}
+
+// spGate8 skips benchmarks whose rows pin the 8-worker chunk geometry:
+// below GOMAXPROCS=8 the dispatcher hands out fewer, larger chunks
+// (96KiB across 4 workers is 24KiB chunks), which take the full
+// sampling budget - or cross the chain floor - under row names that
+// promise the chunk-scale policy, so constrained runners skip loudly
+// instead of reporting numbers for the wrong regime. Sequential
+// controls and the direct looksDense/chainSample microbenchmarks have
+// no worker-count dependency and stay portable.
+func spGate8(b *testing.B) {
+	if procs := runtime.GOMAXPROCS(0); procs < 8 {
+		b.Skipf("rows pin 8-worker chunk geometry; GOMAXPROCS=%d changes the chunk sizes and sampling budgets they document", procs)
+	}
 }
 
 // spDenseCorpus returns 256KiB of concatenated dictionary words: the
@@ -51,11 +56,11 @@ func spDenseCorpus(b *testing.B) []byte {
 }
 
 // assertRegime pins the dispatch decision the experiment depends on,
-// evaluated at the same GOMAXPROCS Match's own dispatch uses (spTrie
-// has already gated the file on >= 8 procs, so a parallel regime here
-// implies the intended 8-worker chunk geometry, not a degenerate 2-4
-// worker split). Passing resets the timer so the assertion's sampling
-// cost stays out of short benchtime runs.
+// evaluated at the same GOMAXPROCS Match's own dispatch uses (parallel
+// groups also call spGate8, so a parallel regime here implies the
+// intended 8-worker chunk geometry, not a degenerate 2-4 worker
+// split). Passing resets the timer so the assertion's sampling cost
+// stays out of short benchtime runs.
 func assertRegime(b *testing.B, tr *Trie, input []byte, wantParallel, wantDense, wantKnown bool) {
 	b.Helper()
 	procs := runtime.GOMAXPROCS(0)
@@ -76,6 +81,7 @@ func assertRegime(b *testing.B, tr *Trie, input []byte, wantParallel, wantDense,
 // and workers chain-vote instead (density only breaks ties). 127 KiB stays
 // under parallelSparseMin, past which the gate stops sampling entirely.
 func BenchmarkSPDenseBand(b *testing.B) {
+	spGate8(b)
 	tr := spTrie(b)
 	corpus := spDenseCorpus(b)
 	for _, size := range []int{32 << 10, 48 << 10, 64 << 10, 96 << 10, 127 << 10} {
@@ -115,6 +121,7 @@ func spHeteroInput(b *testing.B, size int, sparseBlocks map[int]bool) []byte {
 }
 
 func BenchmarkSPHetero(b *testing.B) {
+	spGate8(b)
 	tr := spTrie(b)
 	// 64 KiB = 8 blocks of 8 KiB; looksDense windows land in blocks
 	// 0 (head), 4 (mid), 7 (tail); workers get one block each (p=8).
@@ -213,6 +220,7 @@ func BenchmarkSPLooksDenseCost(b *testing.B) {
 // chunks, below the chain floor) routing falls back to density, so that
 // row covers the density-routed shape of the same input.
 func BenchmarkSPFalseStart(b *testing.B) {
+	spGate8(b)
 	tr := spTrie(b)
 	corpus := spFalseStartCorpus(tr.rootStopBytes[0], 127<<10)
 	for _, size := range []int{64 << 10, 96 << 10, 127 << 10} {
@@ -255,6 +263,7 @@ func BenchmarkSPSeqSmall(b *testing.B) {
 // vote sits in the gray band where sampling-budget changes could flip
 // windows. gap picked at setup so the whole input still gates dense.
 func BenchmarkSPGray(b *testing.B) {
+	spGate8(b)
 	patterns, _ := labLoad(b)
 	tr := spTrie(b)
 	for _, gap := range []int{2, 3} {

--- a/trie.go
+++ b/trie.go
@@ -1075,16 +1075,46 @@ func (tr *Trie) dualWorthwhileDense(input []byte, dense, denseKnown bool) bool {
 	return dense
 }
 
-// chainSample walks four 1KB windows of input the same way the scan
-// loop does and returns how many voted long (local mean excursion
-// length >= dualChainLongMin) and how many voted short (mean <
-// dualChainShortMax); windows with too little evidence abstain. The
-// windows sit at the 1/8, 3/8, 5/8 and 7/8 points - offset from the
-// head/mid/tail windows looksDense counts - so the two signals do not
-// share blind spots: periodic filler that hides the stop bytes from one
-// set of windows still crosses the other. Skip-dominated windows cost a
-// few IndexByte hops; chain-dense windows cost table loads, bounded by
-// the per-window caps.
+// chainSampleSmallMax is the input size below which chainSample runs on
+// a reduced budget: two windows instead of four, each under halved
+// per-window caps. It equals the largest chunk matchParallel hands a
+// worker in the gate-sampled dense band (parallelSparseMin split across
+// the 8-worker cap), so every chunk of such a dispatch - and the
+// sequential inputs just above dualChainFloor - takes the reduced
+// budget, while
+// whole inputs and the >=16KB chunks of larger dispatches keep the full
+// one.
+//
+// The full budget oversamples at this scale: four 1KB windows cover a
+// third of a 12KB chunk, 8x the fraction the same code samples from a
+// whole 96KB input, and on the parallel path every worker walks that
+// budget concurrently before its chunk scan (~17us of an 8-worker
+// dispatch's critical path at 96-127KB; the sample's dependent table
+// loads run ~5x slower under 8-way LLC contention than solo). Halving
+// both caps preserves their ratio, so the byte cap still cuts a window
+// off at the same mean excursion length relative to dualChainLongMin
+// (~25.6 bytes) and the short bar keeps dualChainShortMax; both witness
+// minimums remain attainable under the halved caps, so only the
+// evidence budget shrinks. Measured on Graviton3 (n=24): dense
+// concatenated words -4.8% at 96KB and -3.3% at 127KB, sequential 12KB
+// dense -9.4%, stop-byte-dense/shallow-chain input keeps its
+// single-cursor routing at every size, and word-separator corpora at
+// the density gate's edge improve 5-6% with no vote flips.
+const chainSampleSmallMax = parallelSparseMin / 8
+
+// chainSample walks 1KB windows of input the same way the scan loop
+// does and returns how many voted long (local mean excursion length >=
+// dualChainLongMin) and how many voted short (mean <
+// dualChainShortMax); windows with too little evidence abstain. Whole
+// inputs get four windows at the 1/8, 3/8, 5/8 and 7/8 points; inputs
+// under chainSampleSmallMax (parallel chunks and just-above-floor
+// sequential inputs) get two at the 1/4 and 3/4 points under halved
+// caps. Both layouts are offset from the head/mid/tail windows
+// looksDense counts, so the two signals do not share blind spots:
+// periodic filler that hides the stop bytes from one set of windows
+// still crosses the other. Skip-dominated windows cost a few IndexByte
+// hops; chain-dense windows cost table loads, bounded by the per-window
+// caps.
 //
 // A window usually starts mid-excursion, where the real scan's state is
 // unknown, so each walk warms up from maxLen bytes before its window:
@@ -1096,9 +1126,17 @@ func (tr *Trie) dualWorthwhileDense(input []byte, dense, denseKnown bool) bool {
 func (tr *Trie) chainSample(input []byte) (long, short int) {
 	n := len(input)
 	warm := int(tr.maxLen)
-	for _, num := range [4]int{1, 3, 5, 7} {
-		start := max(num*(n/8)-512, warm)
-		chainBytes, excursions := tr.chainWalk(input[start-warm:min(start+1024, n)], warm)
+	nums := [4]int{1, 3, 5, 7}
+	wcount, den := 4, 8
+	maxSteps, maxExc := dualSampleMaxSteps, dualSampleMaxExcursions
+	if n < chainSampleSmallMax {
+		nums = [4]int{1, 3, 0, 0}
+		wcount, den = 2, 4
+		maxSteps, maxExc = dualSampleMaxSteps/2, dualSampleMaxExcursions/2
+	}
+	for _, num := range nums[:wcount] {
+		start := max(num*(n/den)-512, warm)
+		chainBytes, excursions := tr.chainWalk(input[start-warm:min(start+1024, n)], warm, maxSteps, maxExc)
 		switch {
 		case chainBytes >= dualSampleMinChainBytes && chainBytes >= dualChainLongMin*excursions:
 			long++
@@ -1114,8 +1152,9 @@ func (tr *Trie) chainSample(input []byte) (long, short int) {
 // in-chain runs) observed at or beyond the window start. An excursion
 // already in progress at the warm-up boundary counts once, so a window
 // wholly inside one long excursion still yields evidence. The walk
-// returns early once either per-window cap is reached.
-func (tr *Trie) chainWalk(w []byte, warm int) (chainBytes, excursions int) {
+// returns early once either per-window cap is reached; the caps are
+// parameters because chainSample halves them for small inputs.
+func (tr *Trie) chainWalk(w []byte, warm, maxSteps, maxExc int) (chainBytes, excursions int) {
 	c := tr.rootStopBytes[0]
 	s := rootState
 	// runCounted marks the current excursion as already tallied; it
@@ -1137,7 +1176,7 @@ func (tr *Trie) chainWalk(w []byte, warm int) (chainBytes, excursions int) {
 				excursions++
 				runCounted = true
 			}
-			if chainBytes >= dualSampleMaxSteps || excursions >= dualSampleMaxExcursions {
+			if chainBytes >= maxSteps || excursions >= maxExc {
 				return
 			}
 		}

--- a/trie.go
+++ b/trie.go
@@ -1083,7 +1083,7 @@ func (tr *Trie) dualWorthwhileDense(input []byte, dense, denseKnown bool) bool {
 // just above dualChainFloor - take the reduced budget, while whole
 // inputs and the >=16KB chunks of larger dispatches keep the full one.
 // The strict test sees the worker's slice, not its owned chunk, so the
-// edges fall back to the full (pre-existing, safe) budget rather than
+// edges fall back to the full (safe, more-evidence) budget rather than
 // below it: a sub-8-worker dispatch's larger chunks, a ceiling-division
 // chunk landing exactly on the threshold, and slices whose maxLen-1
 // overlap prefix pushes them over; only when a chunk lands within

--- a/trie.go
+++ b/trie.go
@@ -1079,11 +1079,16 @@ func (tr *Trie) dualWorthwhileDense(input []byte, dense, denseKnown bool) bool {
 // a reduced budget: two windows instead of four, each under halved
 // per-window caps. It equals the largest chunk matchParallel hands a
 // worker in the gate-sampled dense band (parallelSparseMin split across
-// the 8-worker cap), so every chunk of such a dispatch - and the
-// sequential inputs just above dualChainFloor - takes the reduced
-// budget, while
-// whole inputs and the >=16KB chunks of larger dispatches keep the full
-// one.
+// the 8-worker cap), so gate-sampled chunks - and the sequential inputs
+// just above dualChainFloor - take the reduced budget, while whole
+// inputs and the >=16KB chunks of larger dispatches keep the full one.
+// The strict test sees the worker's slice, not its owned chunk, so the
+// edges fall back to the full (pre-existing, safe) budget rather than
+// below it: a sub-8-worker dispatch's larger chunks, a ceiling-division
+// chunk landing exactly on the threshold, and slices whose maxLen-1
+// overlap prefix pushes them over; only when a chunk lands within
+// maxLen-1 bytes below the threshold do sibling workers split between
+// the two budgets.
 //
 // The full budget oversamples at this scale: four 1KB windows cover a
 // third of a 12KB chunk, 8x the fraction the same code samples from a


### PR DESCRIPTION
`chainSample`'s routing vote pays a fixed budget — four 1KB windows, each walking up to 256 chain bytes of dependent `failTrans16` loads — regardless of input size. At chunk scale that budget is mis-sized twice over: four windows cover a third of a 12KB parallel chunk (8x the sampling fraction the same code applies to a whole 96KB input), and on a dense-verdict parallel dispatch every worker walks it concurrently before scanning, where the sample's dependent loads run ~5x slower under 8-way LLC contention than solo (~4.9us → ~27us for 8 workers) — about 17us of the dispatch's critical path at 96–127KB.

Inputs under `chainSampleSmallMax` (`parallelSparseMin/8` = 16KB, the largest chunk a gate-sampled dispatch hands a worker) now sample two windows (1/4, 3/4 points) under halved per-window caps. The cap ratio is preserved (128/12 = 256/24), so the byte cap still cuts a window off at the same mean excursion length relative to `dualChainLongMin` and the short bar keeps `dualChainShortMax` — only the evidence budget shrinks, not the vote's calibration. Whole inputs and ≥16KB chunks keep the full budget.

Alternatives measured and rejected: forcing one global density verdict onto all chunks captures more (-6.7% at 96KB) but mis-routes shallow-chain dense input **+57%** (density says dense, chains die at depth 1, single-cursor wins 1.4x — the chunk-local chain vote is what catches this); computing the vote once at the gate is a critical-path no-op (workers sample concurrently, so wall time is `spawn + sample + scan` either way); a sound early-exit inside the walk does not exist (the long vote is non-monotone in the walk state, and certainty bounds land beyond the caps).

`TestRoutingPreserved` pins the dual-vs-single verdict per corpus shape on both sides of the budget threshold, so a future budget change that flips a scan family's routing fails a test rather than a benchmark.

**Measured** (Graviton3, n=12 interleaved executions vs the stack tip): dense concat words **-3.9%** at 96KB, **-2.8%** at 127KB; sequential 12KB dense **-7.5%**; separator corpora at the density gate's edge **-5.3/-5.6%**; shallow-chain (false-start) input flat-to-better with routing preserved; sparse, hetero, and ≥16KB-chunk controls unchanged. `chainSample` itself: -73% at 12KB, exactly 0 at 16KB+. One noisy row (`ibsen-48k`, ±2% cv) reports +4.3% on a code path byte-identical in both arms; across five earlier same-code binary pairs it swung ±1.7–4.1% both directions — binary-layout artifact, not mechanism.

Follow-up to #32's sampling-guarantee discussion (the deferred half of the per-chunk re-sampling question). Stacked on #36.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This reduces `chainSample`’s work for inputs smaller than 16 KB while preserving routing decisions. Small inputs now use two sampling windows with halved per-window limits; full-sized inputs and chunks retain the existing sampling budget.

## Why it was needed

`chainSample` runs during routing decisions for parallel dispatch. Its fixed sampling budget added unnecessary concurrent-sampling overhead for small inputs, especially in dense-verdict workloads. The change targets that cost without changing the cap ratio or shallow-chain routing behavior.

## How it works

- Inputs below `chainSampleSmallMax` (16 KB) sample windows near the quarter and three-quarter positions.
- Each window uses half the previous step and excursion caps.
- Larger inputs continue using the existing four-window, full-cap sampling layout.
- `chainWalk` now receives explicit limits and stops when either the step or excursion cap is reached.
- `TestRoutingPreserved` compares dual- versus single-cursor routing across the budget boundary using wordlike and falsestart corpora.
- New benchmarks cover dense, heterogeneous, sparse, large-input, gray-zone, false-start, sequential, and direct `chainSample` costs. Runtime-regime assertions use `runtime.GOMAXPROCS` to validate that measurements exercise the intended dispatch paths.

```mermaid
flowchart LR
    A[Input size] -->|below 16 KB| B[Reduced chainSample]
    A -->|16 KB or larger| C[Full chainSample]
    B -->|two windows, halved caps| D[chainWalk]
    C -->|four windows, full caps| D
    D -->|chain/excursion evidence| E[dualWorthwhile routing verdict]

    classDef changed fill:`#fff4cc`,stroke:`#d4a017`,stroke-width:2px
    class B,C,D,E changed
```

## Key decisions

- The reduced layout keeps quarter/three-quarter sampling positions and preserves the cap ratio rather than simply sampling less at the same positions.
- Whole inputs and chunks at or above 16 KB remain unchanged, limiting behavioral risk to the intended small-input regime.
- Gray-zone benchmark results are logged as characterization data instead of being treated as strict pass/fail expectations.

## Review focus

- Verify the small-input threshold and window positions preserve routing calibration.
- Check that both `chainWalk` limits are enforced consistently and that larger inputs retain the previous budget.
- Confirm benchmarks assert the intended runtime regime rather than producing misleading measurements.

## Files

| File | Change |
|---|---|
| `trie.go` | Adds reduced-budget sampling for small inputs and configurable `chainWalk` limits. |
| `routingpreserve_test.go` | Adds routing-preservation coverage across input sizes and corpus shapes. |
| `samplepolicy_bench_test.go` | Adds sampling and dispatch benchmarks with regime validation. |
| `dualscan_test.go` | Generalizes the trie fixture helper to accept `testing.TB`. |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->